### PR TITLE
Adding BAT token by default to accounts, component patching work

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,6 +18,13 @@
   "plugins": [
     "transform-runtime",
     "transform-async-to-generator",
-    "transform-class-properties"
+    "transform-class-properties",
+    [
+    "babel-plugin-root-import",
+      {
+        "braveSuffix": "./",
+        "bravePrefix": "~"
+      }
+    ]
   ]
 }

--- a/brave/app/scripts/controllers/preferences.js
+++ b/brave/app/scripts/controllers/preferences.js
@@ -1,0 +1,16 @@
+const PreferencesController = require('../../../../app/scripts/controllers/preferences')
+
+module.exports = class BravePreferencesController extends PreferencesController {
+  constructor (opts = {}) {
+    if (opts.initState === undefined) {
+      opts['initState'] = {}
+    }
+    opts.initState.batTokenAdded = false
+    super(opts)
+  }
+
+  setBatTokenAdded () {
+    this.store.updateState({ batTokenAdded: true })
+    return Promise.resolve(true)    
+  }
+}

--- a/brave/app/scripts/metamask-controller.js
+++ b/brave/app/scripts/metamask-controller.js
@@ -1,0 +1,14 @@
+const MetamaskController = require('../../../app/scripts/metamask-controller')
+const nodeify = require('../../../app/scripts/lib/nodeify')
+
+module.exports = class BraveController extends MetamaskController {
+  constructor (opts) {
+    super(opts)
+  }
+
+  getApi () {
+    const api = super.getApi()
+    api.setBatTokenAdded = nodeify(this.preferencesController.setBatTokenAdded, this.preferencesController)
+    return api
+  }
+}

--- a/brave/gulp.js
+++ b/brave/gulp.js
@@ -1,0 +1,83 @@
+const gulp = require('gulp')
+const replace = require('gulp-replace')
+
+/*
+ * Brave
+ */
+
+const overrideDirs = [
+  'ui/app/**/*',
+  'app/scripts/**/*'
+]
+
+const bravePrefix = '~/brave/'
+
+/*
+ * ToDo(ryanml) - Write a method to convert simple paths to a Regex obj
+ * then a simple mapping can be created for these replacements.
+ * Ex (psuedo-ish):
+ * const replacements = [
+ *   {
+ *     target: 'actions',
+ *     replace: 'ui/app/store/actions'
+ *   }
+ * ]
+ *
+ * replacements.map((item) => {
+ *   .pipe(
+ *     replace(convertToRegex(item.target), fmtPath(item.replace))
+ *   )
+ * })
+ */
+module.exports = function () {
+  return gulp.src(overrideDirs)
+    .pipe(
+      replace(
+        /\'(.*)\/home\'/gm,
+        `'${bravePrefix}ui/app/pages/home'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'\.\/routes\'/gm,
+        `'${bravePrefix}ui/app/pages/routes'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'(.*)\/actions\'/gm,
+        `'${bravePrefix}ui/app/store/actions'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'(.*)\/preferences\'/gm,
+        `'${bravePrefix}app/scripts/controllers/preferences'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'(.*)\/metamask-controller\'/gm,
+        `'${bravePrefix}app/scripts/metamask-controller'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'(.*)\/metamask\/metamask\'/gm,
+        `'${bravePrefix}ui/app/ducks/metamask/metamask'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'(.*)\/components\/menu\'/gm,
+        `'${bravePrefix}ui/app/components/app/dropdowns/components/menu'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'(.*)\/token-menu-dropdown\.js\'/gm,
+        `'${bravePrefix}ui/app/components/app/dropdowns/token-menu-dropdown'`
+      )
+    )
+    .pipe(gulp.dest(file => file.base))
+}

--- a/brave/ui/app/components/app/dropdowns/components/menu.js
+++ b/brave/ui/app/components/app/dropdowns/components/menu.js
@@ -1,0 +1,30 @@
+const h = require('react-hyperscript')
+
+import { Menu, Item, Divider, CloseArea } from '../../../../../../../ui/app/components/app/dropdowns/components/menu'
+
+Item.prototype.render = function () {
+  const {
+    icon,
+    children,
+    text,
+    className = '',
+    onClick,
+    isShowing
+  } = this.props
+
+  if (isShowing === false) {
+    return h('noscript')
+  }
+
+  const itemClassName = `menu__item ${className} ${onClick ? 'menu__item--clickable' : ''}`
+  const iconComponent = icon ? h('div.menu__item__icon', [icon]) : null
+  const textComponent = text ? h('div.menu__item__text', text) : null
+
+  return children
+    ? h('div', { className: itemClassName, onClick }, children)
+    : h('div.menu__item', { className: itemClassName, onClick }, [ iconComponent, textComponent ]
+        .filter(d => Boolean(d))
+    )    
+}
+
+module.exports = { Menu, Item, Divider, CloseArea }

--- a/brave/ui/app/components/app/dropdowns/token-menu-dropdown.js
+++ b/brave/ui/app/components/app/dropdowns/token-menu-dropdown.js
@@ -1,0 +1,74 @@
+const Component = require('react').Component
+const PropTypes = require('prop-types')
+const h = require('react-hyperscript')
+const inherits = require('util').inherits
+const connect = require('react-redux').connect
+const genAccountLink = require('etherscan-link').createAccountLink
+const { Menu, Item, CloseArea } = require('./components/menu')
+
+import actions from '../../../store/actions'
+
+function mapStateToProps(state) {
+  return {
+    network: state.metamask.network,
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    showHideTokenConfirmationModal: (token) => {
+      dispatch(actions.showModal({
+        name: 'HIDE_TOKEN_CONFIRMATION',
+        token
+      }))
+    },
+  }
+}
+
+BraveTokenMenuDropdown.contextTypes = {
+  t: PropTypes.func,
+}
+
+inherits(BraveTokenMenuDropdown, Component)
+function BraveTokenMenuDropdown () {
+  Component.call(this)
+
+  this.onClose = this.onClose.bind(this)
+}
+
+BraveTokenMenuDropdown.prototype.onClose = function (e) {
+  e.stopPropagation()
+  this.props.onClose()
+}
+
+BraveTokenMenuDropdown.prototype.render = function() {
+  const { showHideTokenConfirmationModal } = this.props
+
+  return h(Menu, { className: 'token-menu-dropdown', isShowing: true }, [
+    h(CloseArea, {
+      onClick: this.onClose,
+    }),
+    h(Item, {
+      onClick: (e) => {
+        e.stopPropagation()
+        showHideTokenConfirmationModal(this.props.token)
+        this.props.onClose()
+      },
+      isShowing: (this.props.token.symbol !== 'BAT'),
+      text: 'Hide Tokens',
+    }),
+    h(Item, {
+      onClick: (e) => {
+        e.stopPropagation()
+        const url = genAccountLink(this.props.token.address, this.props.network)
+        global.platform.openWindow({
+          url
+        })
+        this.props.onClose()
+      },
+      text: 'View on Etherscan',
+    }),
+  ])
+}
+
+module.exports = connect(mapStateToProps, mapDispatchToProps)(BraveTokenMenuDropdown)

--- a/brave/ui/app/ducks/metamask/metamask.js
+++ b/brave/ui/app/ducks/metamask/metamask.js
@@ -1,0 +1,12 @@
+const reduceMetamask = require('../../../../../ui/app/ducks/metamask/metamask')
+
+module.exports = function (state, action) {
+  const newState = reduceMetamask(state, action)
+  newState.batTokenAdded = newState.batTokenAdded || false
+
+  if (action.type === 'SET_BAT_TOKEN_ADDED') {
+    newState.batTokenAdded = action.value
+  }
+
+  return newState
+}

--- a/brave/ui/app/pages/home/home.component.js
+++ b/brave/ui/app/pages/home/home.component.js
@@ -1,0 +1,24 @@
+import Home from '../../../../../ui/app/pages/home/home.component'
+import PropTypes from 'prop-types'
+import actions from '../../store/actions'
+import batToken from '../../store/bat-token'
+
+const BraveHome = class BraveHome extends Home {
+  constructor (props) {
+    super(props)
+  }
+
+  componentDidMount () {
+    super.componentDidMount()
+
+    const { batTokenAdded } = this.props
+
+    if (!batTokenAdded) {
+      this.props.dispatch(actions.addTokens(batToken))
+    }    
+  }
+}
+
+BraveHome.propTypes.batTokenAdded = PropTypes.bool
+
+module.exports = BraveHome

--- a/brave/ui/app/pages/home/home.container.js
+++ b/brave/ui/app/pages/home/home.container.js
@@ -1,0 +1,32 @@
+import Home from './home.component'
+import { compose } from 'recompose'
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
+import { unconfirmedTransactionsCountSelector } from '../../../../../ui/app/selectors/confirm-transaction'
+
+const mapStateToProps = state => {
+  const { metamask, appState } = state
+  const {
+    lostAccounts,
+    seedWords,
+    suggestedTokens,
+    providerRequests,
+    batTokenAdded
+  } = metamask
+  const { forgottenPassword } = appState
+
+  return {
+    lostAccounts,
+    forgottenPassword,
+    seedWords,
+    suggestedTokens,
+    unconfirmedTransactionsCount: unconfirmedTransactionsCountSelector(state),
+    providerRequests,
+    batTokenAdded
+  }
+}
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps)
+)(Home)

--- a/brave/ui/app/pages/home/index.js
+++ b/brave/ui/app/pages/home/index.js
@@ -1,0 +1,1 @@
+export { default } from './home.container'

--- a/brave/ui/app/pages/routes/index.js
+++ b/brave/ui/app/pages/routes/index.js
@@ -1,0 +1,112 @@
+const Routes = require('../../../../../ui/app/pages/routes')
+
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { compose } from 'recompose'
+import { withRouter } from 'react-router-dom'
+
+import {
+  getMetaMaskAccounts,
+  getNetworkIdentifier,
+  preferencesSelector
+} from '../../../../../ui/app/selectors/selectors'
+import {
+  submittedPendingTransactionsSelector
+} from '../../../../../ui/app/selectors/transactions'
+
+import actions from '../../store/actions'
+
+function mapStateToProps(state) {
+  const { appState, metamask } = state
+  const {
+    networkDropdownOpen,
+    sidebar,
+    alertOpen,
+    alertMessage,
+    isLoading,
+    loadingMessage,
+  } = appState
+
+  const accounts = getMetaMaskAccounts(state)
+  const { autoLogoutTimeLimit = 0 } = preferencesSelector(state)
+
+  const {
+    identities,
+    address,
+    keyrings,
+    isInitialized,
+    seedWords,
+    unapprovedTxs,
+    lostAccounts,
+    unapprovedMsgCount,
+    unapprovedPersonalMsgCount,
+    unapprovedTypedMessagesCount,
+    providerRequests,
+    batTokenAdded
+  } = metamask
+  const selected = address || Object.keys(accounts)[0]
+
+  return {
+    // state from plugin
+    networkDropdownOpen,
+    sidebar,
+    alertOpen,
+    alertMessage,
+    isLoading,
+    loadingMessage,
+    isInitialized,
+    isUnlocked: state.metamask.isUnlocked,
+    selectedAddress: state.metamask.selectedAddress,
+    currentView: state.appState.currentView,
+    activeAddress: state.appState.activeAddress,
+    transForward: state.appState.transForward,
+    isOnboarding: Boolean(seedWords || !isInitialized),
+    isPopup: state.metamask.isPopup,
+    seedWords: state.metamask.seedWords,
+    submittedPendingTransactions: submittedPendingTransactionsSelector(state),
+    unapprovedTxs,
+    unapprovedMsgs: state.metamask.unapprovedMsgs,
+    unapprovedMsgCount,
+    unapprovedPersonalMsgCount,
+    unapprovedTypedMessagesCount,
+    menuOpen: state.appState.menuOpen,
+    network: state.metamask.network,
+    provider: state.metamask.provider,
+    forgottenPassword: state.appState.forgottenPassword,
+    lostAccounts,
+    frequentRpcListDetail: state.metamask.frequentRpcListDetail || [],
+    currentCurrency: state.metamask.currentCurrency,
+    isMouseUser: state.appState.isMouseUser,
+    isRevealingSeedWords: state.metamask.isRevealingSeedWords,
+    Qr: state.appState.Qr,
+    welcomeScreenSeen: state.metamask.welcomeScreenSeen,
+    providerId: getNetworkIdentifier(state),
+    autoLogoutTimeLimit,
+
+    identities,
+    selected,
+    keyrings,
+    providerRequests,
+    batTokenAdded
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    dispatch,
+    hideSidebar: () => dispatch(actions.hideSidebar()),
+    showNetworkDropdown: () => dispatch(actions.showNetworkDropdown()),
+    hideNetworkDropdown: () => dispatch(actions.hideNetworkDropdown()),
+    setCurrentCurrencyToUSD: () => dispatch(actions.setCurrentCurrency('usd')),
+    toggleAccountMenu: () => dispatch(actions.toggleAccountMenu()),
+    setMouseUserState: (isMouseUser) => dispatch(actions.setMouseUserState(isMouseUser)),
+    setLastActiveTime: () => dispatch(actions.setLastActiveTime()),
+  }
+}
+
+Routes.propTypes['batTokenAdded'] = PropTypes.bool
+
+module.exports = compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps)
+)(Routes)

--- a/brave/ui/app/store/actions.js
+++ b/brave/ui/app/store/actions.js
@@ -1,0 +1,40 @@
+const MetaMaskActions = require('../../../../ui/app/store/actions')
+
+MetaMaskActions.addToken = addToken
+MetaMaskActions.setBatTokenAdded = setBatTokenAdded
+MetaMaskActions.SET_BAT_TOKEN_ADDED = 'SET_BAT_TOKEN_ADDED'
+
+function setBatTokenAdded () {
+  return (dispatch) => {
+    background.setBatTokenAdded((err) => {
+      if (err) {
+        return dispatch(actions.displayWarning(err.message))
+      }
+    })
+    dispatch({
+      type: actions.SET_BAT_TOKEN_ADDED,
+      value: true
+    })
+  }
+}
+
+function addToken (address, symbol, decimals, image) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    return new Promise((resolve, reject) => {
+      background.addToken(address, symbol, decimals, image, (err, tokens) => {
+        dispatch(actions.hideLoadingIndication())
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          reject(err)
+        } else if (symbol === 'BAT') {
+          dispatch(actions.setBatTokenAdded())
+        }
+        dispatch(actions.updateTokens(tokens))
+        resolve(tokens)
+      })
+    })
+  }
+}
+
+module.exports = MetaMaskActions

--- a/brave/ui/app/store/bat-token.js
+++ b/brave/ui/app/store/bat-token.js
@@ -1,0 +1,10 @@
+export default {
+    '0x0D8775F648430679A709E98d2b0Cb6250d2887EF': {
+      'name': 'Basic Attention Token',
+      'logo': 'BAT_icon.svg',
+      'erc20': true,
+      'symbol': 'BAT',
+      'decimals': 18,
+      'address' :'0x0D8775F648430679A709E98d2b0Cb6250d2887EF'
+    }
+  }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,8 @@ const materialUIDependencies = ['@material-ui/core']
 const reactDepenendencies = dependencies.filter(dep => dep.match(/react/))
 const d3Dependencies = ['c3', 'd3']
 
+const braveGulp = require('./brave/gulp')
+
 const uiDependenciesToBundle = [
   ...materialUIDependencies,
   ...reactDepenendencies,
@@ -400,6 +402,7 @@ gulp.task('zip', gulp.parallel('zip:chrome', 'zip:firefox', 'zip:edge', 'zip:ope
 
 gulp.task('dev',
   gulp.series(
+    braveGulp,
     'clean',
     'dev:scss',
     gulp.parallel(

--- a/package-lock.json
+++ b/package-lock.json
@@ -4465,6 +4465,15 @@
         "react-docgen": "^3.0.0-beta11"
       }
     },
+    "babel-plugin-root-import": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-root-import/-/babel-plugin-root-import-6.2.0.tgz",
+      "integrity": "sha512-Tsq1pfSRn2XkNOrMXOYoTAxYddvWC21850h8Cj6xozccwr50WQu+GrzrHmr9RAmHCaLVUOfFYe3cshpQbDmf4w==",
+      "dev": true,
+      "requires": {
+        "slash": "^1.0.0"
+      }
+    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
@@ -16738,6 +16747,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {
@@ -20721,6 +20747,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "addons-linter": "^1.3.4",
     "babel-core": "^6.24.1",
     "babel-eslint": "^8.0.0",
+    "babel-plugin-root-import": "^6.2.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/4773
Fixes: https://github.com/brave/brave-browser/issues/4924

This PR contains the initial patching strategy for overriding MM components without any actual patches :)

This adds BAT to the user list of tokens by default after creating their account

Ideally this would have been done just by placing the BAT token object in the default store, but this proved to be a little too complicated for a few reasons. A one time add via an existing action proved to be much more simple and reliable:

Main View:
<img width="893" alt="Screen Shot 2019-06-10 at 5 03 21 PM" src="https://user-images.githubusercontent.com/8732757/59234803-32d10500-8ba3-11e9-81f2-caaa42320392.png">

Non Removable:
<img width="364" alt="Screen Shot 2019-06-10 at 4 57 41 PM" src="https://user-images.githubusercontent.com/8732757/59234807-3795b900-8ba3-11e9-90bc-ca65c16d37df.png">

With other assets:
<img width="917" alt="Screen Shot 2019-06-10 at 4 57 32 PM" src="https://user-images.githubusercontent.com/8732757/59234815-42504e00-8ba3-11e9-890a-c5eedbe9b417.png">


