### PR TITLE
Disables Telemetry opt-in screen/networking

### DIFF
--- a/brave/app/scripts/lib/backend-metametrics.js
+++ b/brave/app/scripts/lib/backend-metametrics.js
@@ -1,0 +1,1 @@
+module.exports = (metaMaskState, eventData) => { /* no-op */ }

--- a/brave/gulp.js
+++ b/brave/gulp.js
@@ -88,5 +88,17 @@ module.exports = function () {
         `@import 'ui-migration-annoucement/index'; @import '${braveStyleRelative}ui/app/components/app/header/index';`
       )
     )
+    .pipe(
+      replace(
+        /\'(.*)\/select-action\.component\'/gm,
+        `'${bravePrefix}ui/app/pages/first-time-flow/select-action/select-action.component'`
+      )
+    )
+    .pipe(
+      replace(
+        /\'(.*)\/lib\/backend-metametrics\'/gm,
+        `'${bravePrefix}app/scripts/lib/backend-metametrics'`
+      )
+    )
     .pipe(gulp.dest(file => file.base))
 }

--- a/brave/ui/app/pages/first-time-flow/select-action/select-action.component.js
+++ b/brave/ui/app/pages/first-time-flow/select-action/select-action.component.js
@@ -1,0 +1,21 @@
+import SelectAction from '../../../../../../ui/app/pages/first-time-flow/select-action/select-action.component'
+import {
+  INITIALIZE_CREATE_PASSWORD_ROUTE
+} from '../../../../../../ui/app/helpers/constants/routes'
+
+
+module.exports = class BraveSelectAction extends SelectAction {
+  constructor (props) {
+    super(props)
+  }
+
+  handleCreate = () => {
+    this.props.setFirstTimeFlowType('create')
+    this.props.history.push(INITIALIZE_CREATE_PASSWORD_ROUTE)
+  }
+
+  handleImport = () => {
+    this.props.setFirstTimeFlowType('import')
+    this.props.history.push(INITIALIZE_CREATE_PASSWORD_ROUTE)
+  }
+}

--- a/brave/ui/app/store/actions.js
+++ b/brave/ui/app/store/actions.js
@@ -4,6 +4,8 @@ MetaMaskActions.addToken = addToken
 MetaMaskActions.setBatTokenAdded = setBatTokenAdded
 MetaMaskActions.SET_BAT_TOKEN_ADDED = 'SET_BAT_TOKEN_ADDED'
 
+MetaMaskActions.showModal = showModal
+
 function setBatTokenAdded () {
   return (dispatch) => {
     background.setBatTokenAdded((err) => {
@@ -34,6 +36,20 @@ function addToken (address, symbol, decimals, image) {
         resolve(tokens)
       })
     })
+  }
+}
+
+function showModal (payload) {
+  if (payload.name === 'METAMETRICS_OPT_IN_MODAL') {
+    return {
+      type: '',
+      payload: {}
+    }
+  }
+
+  return {
+    type: actions.MODAL_OPEN,
+    payload,
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/4771

Technically if the opt-in never occurs the metric events never have a chance of getting sent, but as an extra measure the networking code is made unreachable by this PR. cc: @tomlowenthal 