### PR TITLE
Only opening new tab on dapp request for unitialized wallets

### DIFF
--- a/brave/app/scripts/metamask-controller.js
+++ b/brave/app/scripts/metamask-controller.js
@@ -1,7 +1,34 @@
 const MetamaskController = require('../../../app/scripts/metamask-controller')
+const ProviderApprovalController = require('../../../app/scripts/controllers/provider-approval')
 const nodeify = require('../../../app/scripts/lib/nodeify')
 
 module.exports = class BraveController extends MetamaskController {
+
+  constructor (opts) {
+    super(opts)
+
+    this.optsOpenPopup = opts.openPopup
+    this.providerApprovalController = new ProviderApprovalController({
+      closePopup: opts.closePopup,
+      openPopup: this.openPopup.bind(this),
+      keyringController: this.keyringController,
+      preferencesController: this.preferencesController,
+    })
+
+    this.memStore.config.ProviderApprovalController = this.providerApprovalController.store
+    this.memStore.subscribe(this.sendUpdate.bind(this))
+  }
+
+  openPopup () {
+    const prefStore = this.preferencesController.store
+    const hasOnboarded = prefStore.getState().completedOnboarding
+
+    if (hasOnboarded) {
+      this.optsOpenPopup()
+    } else {
+      chrome.tabs.create({ url: 'chrome://wallet/home.html' })
+    }
+  }
 
   getApi () {
     const api = super.getApi()


### PR DESCRIPTION
This adds a proxy to the passed `openPopup` method for `ProviderApprovalController`

Provider approval requests will just open the welcome page in a new tab for users who have not onboarded/started MM, and will not attempt to create a notification

Provider approval functions as expected once user has created an account