### PR TITLE
make sure imported Muli and Poppins fonts are used

### DIFF
--- a/brave/ui/app/components/app/header/index.scss
+++ b/brave/ui/app/components/app/header/index.scss
@@ -1,5 +1,3 @@
-@import url('./fonts/poppins.css');
-
 .br-toolbar {
   position: relative;
   height: 56px;
@@ -25,9 +23,6 @@
   display: flex;
   align-items: center;
   overflow: hidden;
-  font-family: Poppins;
-  font-size: 16px;
-  font-weight: 300;
   letter-spacing: 0.6px;
   text-decoration: none;
   color: #fff;
@@ -71,6 +66,9 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-family: Poppins;
+  font-size: 16px;
+  font-weight: 300;
 }
 
 @media only screen and (max-width: 1067px) {
@@ -100,4 +98,3 @@
 .app {
   overflow-y: hidden;
 }
-

--- a/brave/ui/app/components/app/style/fonts.scss
+++ b/brave/ui/app/components/app/style/fonts.scss
@@ -2,14 +2,20 @@
  * Brave Generic Font Rules
  */
 
+@import url('./fonts/muli.css');
+@import url('./fonts/poppins.css');
+
 button {
-  font-family: Muli-Bold;
+  font-family: Muli;
+  font-weight: bold;
 }
 
 p, span, label, div, a, input {
-  font-family: Muli-Regular;
+  font-family: Muli;
+  font-weight: normal;
 }
 
 h1, h2, h3, h4, h5 {
-  font-family: Poppins-Medium;
+  font-family: Poppins;
+  font-weight: normal;
 }


### PR DESCRIPTION
Also, make sure Poppins is used in the header navbar. It had been unintentionally overridden by the general `span` rule in `fonts.scss`.