### PR TITLE
make scss import injection robust

### DIFF
--- a/brave/gulpfile.js/brave-load-styles.js
+++ b/brave/gulpfile.js/brave-load-styles.js
@@ -20,8 +20,11 @@ const createBraveLoadStylesTask = () => {
     return gulp.src(appRootScss)
       .pipe(
         replace(
-          /@import 'ui-migration-annoucement\/index';/gm,
-          `@import 'ui-migration-annoucement/index'; ${braveImports.join('')}`
+          // looks for "/* BRAVE */<oldimports>" at the
+          // end of the file and replaces it if it's
+          // there, otherwise just appends to the file
+          /(?:\/\*BRAVE\*\/.*)?$/,
+          `/*BRAVE*/${braveImports.join('')}`
         )
       )
       .pipe(gulp.dest(file => file.base))


### PR DESCRIPTION
This creates a more robust method for injecting our SCSS imports. The old method will be broken when the file that we are injecting into changes. This method does not rely on any knowledge of the file.