### PR TITLE
Removing redundant test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ branches:
   only:
     - master
 env:
-  - TEST_SUITE=lint
   - TEST_SUITE=test
 script:
   - npm run $TEST_SUITE


### PR DESCRIPTION
Lint was part of the integration test suite already