### PR TITLE
Adjusting travis for yarn, node version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: node_js
 node_js:
-  - "8.11.3"
+  - "10.16.0"
 addons:
   chrome: 
     stable
 dist: trusty
-cache: npm
+cache:
+  yarn: true
 before_install:
-  - npm --version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
+  - export PATH="$HOME/.yarn/bin:$PATH"
+  - yarn --version
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 branches:
@@ -16,4 +19,4 @@ branches:
 env:
   - TEST_SUITE=test
 script:
-  - npm run $TEST_SUITE
+  - yarn $TEST_SUITE


### PR DESCRIPTION
This gets our CI to run the test/lint suite using yarn

Lint errors after rebase will be addressed here: https://github.com/brave/ethereum-remote-client/pull/41

Test errors will be addressed in a separate PR which will patch failures related to our custom key/seed work