### PR TITLE
Fixing account creation modal

### DIFF
--- a/brave/ui/app/pages/first-time-flow/create-password/index.scss
+++ b/brave/ui/app/pages/first-time-flow/create-password/index.scss
@@ -1,3 +1,9 @@
 .first-time-flow__checkbox-container {
   display: none;
 }
+
+@media screen and (min-width: 576px) {
+  .new-account {
+    position: static;
+  }
+}


### PR DESCRIPTION
This broke after the rebase:

Was:
<img width="701" alt="Screen Shot 2019-08-13 at 4 21 07 PM" src="https://user-images.githubusercontent.com/8732757/62984035-7421a300-bde6-11e9-9c6f-6009068072f2.png">

With fix:
<img width="805" alt="Screen Shot 2019-08-13 at 4 19 57 PM" src="https://user-images.githubusercontent.com/8732757/62984038-77b52a00-bde6-11e9-846b-7407199bc0af.png">

