### PR TITLE
Fixing dapp sig request notification layout

### DIFF
--- a/brave/ui/app/components/app/request-signature/index.scss
+++ b/brave/ui/app/components/app/request-signature/index.scss
@@ -1,0 +1,3 @@
+.request-signature__container {
+  height: 620px;
+}


### PR DESCRIPTION
This rule should not have been specific to a viewport: https://github.com/brave/ethereum-remote-client/blob/master/ui/app/css/itcss/components/request-signature.scss#L22

<img width="1109" alt="Screen Shot 2019-08-13 at 10 37 09 PM" src="https://user-images.githubusercontent.com/8732757/62996830-0cd21600-be1b-11e9-9cbf-2cfad3086354.png">
