### PR TITLE
update eth-keyring-controller dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8677,7 +8677,7 @@ eth-keyring-controller@^4.0.0:
 
 "eth-keyring-controller@github:brave/KeyringController":
   version "5.0.0"
-  resolved "https://codeload.github.com/brave/KeyringController/tar.gz/3219a250980d4fa574901a5d0b2aba7e494ddae9"
+  resolved "https://codeload.github.com/brave/KeyringController/tar.gz/edef6d73b5da827e1f1236a54846fd2a4cf56f37"
   dependencies:
     argon2-wasm "^0.9.0"
     bip39 "^2.4.0"


### PR DESCRIPTION
This fixes the "Cannot read property 'password' of undefined" errors when using hardware wallets.

![trezor](https://user-images.githubusercontent.com/1581504/63134479-69017b00-bf7e-11e9-914f-de89efd77aec.png)
