### PR TITLE
Hiding About tab in settings

### DIFF
--- a/brave/ui/app/pages/settings/index.scss
+++ b/brave/ui/app/pages/settings/index.scss
@@ -1,4 +1,6 @@
-/* Targeting settings page TOS link */
-div.settings-page__content-row > div:nth-child(2) > div:nth-child(3) {
+/* MM TOS Link */
+div.settings-page__content-row > div:nth-child(2) > div:nth-child(3),
+/* MM About tab link */
+div.settings-page__content__tabs > div > div:nth-child(6) {
   display: none;
 }


### PR DESCRIPTION
<img width="887" alt="Screen Shot 2019-08-19 at 2 33 52 PM" src="https://user-images.githubusercontent.com/8732757/63301018-6bb9e400-c28e-11e9-842a-59662ccd569b.png">
