### PR TITLE
Hiding Info & Help menu dropdown item

### DIFF
--- a/brave/ui/app/pages/settings/index.scss
+++ b/brave/ui/app/pages/settings/index.scss
@@ -1,6 +1,8 @@
 /* MM TOS Link */
 div.settings-page__content-row > div:nth-child(2) > div:nth-child(3),
 /* MM About tab link */
-div.settings-page__content__tabs > div > div:nth-child(6) {
+div.settings-page__content__tabs > div > div:nth-child(6),
+/* Dropdown Info & Help Link */
+div.menu.account-menu > div:nth-child(10) {
   display: none;
 }


### PR DESCRIPTION
This linked out to the About tab, which now is hidden
<img width="403" alt="Screen Shot 2019-08-20 at 2 36 25 PM" src="https://user-images.githubusercontent.com/8732757/63386536-2c57ca00-c358-11e9-9e0b-721e98e9ef3d.png">
