### PR TITLE
Removing mobile sync prompt from advanced tab

### DIFF
--- a/brave/gulpfile.js/brave-replace-paths.js
+++ b/brave/gulpfile.js/brave-replace-paths.js
@@ -184,6 +184,12 @@ const createBraveReplacePathsTask = () => {
           `'${bravePrefix}ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component'`
         )
       )
+      .pipe(
+        replace(
+          /'(.*)\/advanced-tab\.component'/gm,
+          `'${bravePrefix}ui/app/pages/settings/advanced-tab/advanced-tab.component'`
+        )
+      )
       .pipe(gulp.dest(file => file.base))
   })
 }

--- a/brave/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/brave/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -1,0 +1,8 @@
+import AdvancedTab from '../../../../../../ui/app/pages/settings/advanced-tab/advanced-tab.component'
+
+module.exports = class BraveAdvancedTab extends AdvancedTab {
+
+  renderMobileSync () {
+    return null
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/5748

<img width="666" alt="Screen Shot 2019-08-20 at 3 25 46 PM" src="https://user-images.githubusercontent.com/8732757/63388918-d9354580-c35e-11e9-9149-41b05ce14f84.png">
