### PR TITLE
Using translated string for end of flow messaging

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -620,7 +620,7 @@
     "message": "If you ever have questions or see something fishy, email support@metamask.io."
   },
   "endOfFlowMessage8": {
-    "message": "MetaMask cannot recover your seedphrase. Learn more."
+    "message": "MetaMask cannot recover your seedphrase."
   },
   "endOfFlowMessage9": {
     "message": "Learn more."

--- a/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
@@ -49,7 +49,7 @@ export default class EndOfFlowScreen extends PureComponent {
           { '• ' + t('endOfFlowMessage7') }
         </div>
         <div className="first-time-flow__text-block end-of-flow__text-4">
-          *MetaMask cannot recover your seedphrase. <a
+          { '*' + t('endOfFlowMessage8') } <a
             href="https://metamask.zendesk.com/hc/en-us/articles/360015489591-Basic-Safety-Tips"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
This fixes the MM -> Brave replace in this view:

<img width="503" alt="Screen Shot 2019-08-23 at 2 37 14 PM" src="https://user-images.githubusercontent.com/8732757/63625145-91f3c280-c5b3-11e9-9c9d-5b17635a35b1.png">
