### PR TITLE
Allowing only moderate and above dep vulns to fail audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ branches:
   only:
     - master
 env:
-  - TEST_SUITE=test
+  - TEST_SUITE=test:ci
 script:
   - yarn $TEST_SUITE

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "publish-docs": "gh-pages -d docs/jsdocs",
     "start:test": "gulp dev:test",
     "build:test": "gulp build:test",
-    "test": "yarn audit && yarn install-test-deps && yarn test:unit && yarn lint",
+    "test:base": "yarn install-test-deps && yarn test:unit && yarn lint",
+    "test:ci": "yarn test:base && node scripts/audit.js",
+    "test": "yarn test:base && yarn audit",
     "dapp": "static-server test/e2e/contract-test --port 8080",
     "dapp-chain": "GANACHE_ARGS='-b 2' concurrently -k -n ganache,dapp -p '[{time}][{name}]' 'yarn ganache:start' 'sleep 5 && static-server test/e2e/contract-test --port 8080'",
     "watch:test:unit": "nodemon --exec \"yarn test:unit\" ./test ./app ./ui",
@@ -279,5 +281,8 @@
   "engines": {
     "node": "^10.16.0",
     "yarn": "^1.16.0"
+  },
+  "resolutions": {
+    "braces": "^2.3.2"
   }
 }

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -1,0 +1,35 @@
+const execSync = require('child_process').execSync
+
+// Yarn audit status codes:
+//
+// Only moderate warnings and above should be taken in to consideration
+//
+// 1 - INFO
+// 2 - LOW
+// 4 - MODERATE
+// 8 - HIGH
+// 16 - CRITICAL
+
+try {
+  return execSync('yarn audit')
+} catch (e) {
+  const stdout = e.stdout.toString()
+
+  if (e.status >= 4) {
+    console.log(stdout)
+    throw new Error('Moderate or higher vulnerabilities found during yarn audit')
+  }
+
+  const numLowVulns = stdout.match(/Package\b/g).length
+
+  if (numLowVulns >= 10) {
+    console.log(stdout)
+    throw new Error(`10 or more low vulnerabilities identified`)
+  }
+
+  console.log('-'.repeat(30))
+  console.log('Audit complete')
+  console.log('-'.repeat(30))
+
+  return process.exit(0)
+}


### PR DESCRIPTION
We have `yarn audit` as a part of our CI checks, currently, even `INFO` and `LOW` notices will cause it to fail. These types of errors are too frequent and will likely be present majority of the time. This PR adds a proxy script so that only moderate, high, and critical vulnerabilities cause a CI failure.