### PR TITLE
Redirects user to hardware connect after creating wallet

### DIFF
--- a/brave/app/scripts/controllers/preferences.js
+++ b/brave/app/scripts/controllers/preferences.js
@@ -6,6 +6,7 @@ module.exports = class BravePreferencesController extends PreferencesController 
       opts['initState'] = {}
     }
     opts.initState.batTokenAdded = false
+    opts.initState.hardwareConnect = false
     opts.initState.rewardsDisclosureAccepted = false
     super(opts)
   }
@@ -18,5 +19,9 @@ module.exports = class BravePreferencesController extends PreferencesController 
   setRewardsDisclosureAccepted () {
     this.store.updateState({ rewardsDisclosureAccepted: true })
     return Promise.resolve(true)
+  }
+
+  setHardwareConnect (value) {
+    this.store.updateState({ hardwareConnect: value })
   }
 }

--- a/brave/app/scripts/metamask-controller.js
+++ b/brave/app/scripts/metamask-controller.js
@@ -33,6 +33,7 @@ module.exports = class BraveController extends MetamaskController {
   getApi () {
     const api = super.getApi()
     api.setBatTokenAdded = nodeify(this.preferencesController.setBatTokenAdded, this.preferencesController)
+    api.setHardwareConnect = nodeify(this.preferencesController.setHardwareConnect, this.preferencesController)
     api.setRewardsDisclosureAccepted = nodeify(this.preferencesController.setRewardsDisclosureAccepted, this.preferencesController)
     return api
   }

--- a/brave/ui/app/components/app/connect-wallet/connect-wallet.component.js
+++ b/brave/ui/app/components/app/connect-wallet/connect-wallet.component.js
@@ -10,6 +10,17 @@ module.exports = class ConnectWallet extends PureComponent {
     type: PropTypes.string,
     onCreate: PropTypes.func,
     onRestore: PropTypes.func,
+    setHardwareConnect: PropTypes.func,
+  }
+
+  onAction = (func) => {
+    const { type } = this.props
+
+    if (type !== 'browser') {
+      this.props.setHardwareConnect(true)
+    }
+
+    func()
   }
 
   renderWalletText = () => {
@@ -74,7 +85,7 @@ module.exports = class ConnectWallet extends PureComponent {
             onCreate
               ? <button
                 style={hwButtonStyle}
-                onClick={onCreate}
+                onClick={this.onAction.bind(this, onCreate)}
                 className={'create'}
               >
                 {innerText}
@@ -84,7 +95,7 @@ module.exports = class ConnectWallet extends PureComponent {
           {
             onRestore
               ? <span
-                onClick={onRestore}
+                onClick={this.onAction.bind(this, onRestore)}
                 className={'restore'}
               >
                 {'Restore'}

--- a/brave/ui/app/components/app/connect-wallet/connect-wallet.container.js
+++ b/brave/ui/app/components/app/connect-wallet/connect-wallet.container.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
+import { compose } from 'recompose'
+import { setHardwareConnect } from '../../../store/actions'
+import ConnectWallet from './connect-wallet.component'
+
+const mapDispatchToProps = dispatch => {
+  return {
+    setHardwareConnect: (value) => dispatch(setHardwareConnect(value)),
+  }
+}
+
+export default compose(
+  withRouter,
+  connect(null, mapDispatchToProps)
+)(ConnectWallet)

--- a/brave/ui/app/components/app/connect-wallet/index.js
+++ b/brave/ui/app/components/app/connect-wallet/index.js
@@ -1,1 +1,1 @@
-export { default } from './connect-wallet.component'
+export { default } from './connect-wallet.container'

--- a/brave/ui/app/pages/first-time-flow/welcome/welcome.component.js
+++ b/brave/ui/app/pages/first-time-flow/welcome/welcome.component.js
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
 import WelcomeModal from '../welcome-modal'
-import Welcome from '../../../../../../ui/app/pages/first-time-flow/welcome/welcome.component'
 import ConnectWallet from '../../../components/app/connect-wallet'
 
 import {
@@ -8,7 +8,10 @@ import {
   INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE,
 } from '../../../../../../ui/app/helpers/constants/routes'
 
-module.exports = class BraveWelcome extends Welcome {
+module.exports = class BraveWelcome extends PureComponent {
+  static propTypes = {
+    history: PropTypes.object,
+  }
 
   onCreate = () => {
     this.props.history.push(INITIALIZE_CREATE_PASSWORD_ROUTE)

--- a/brave/ui/app/pages/home/home.component.js
+++ b/brave/ui/app/pages/home/home.component.js
@@ -1,20 +1,31 @@
 import Home from '../../../../../ui/app/pages/home/home.component'
 import PropTypes from 'prop-types'
+import { CONNECT_HARDWARE_ROUTE } from '../../helpers/constants/routes'
 
 const BraveHome = class BraveHome extends Home {
 
   componentDidMount () {
     super.componentDidMount()
 
-    const { batTokenAdded, addBatToken } = this.props
+    const {
+      batTokenAdded,
+      addBatToken,
+      hardwareConnect,
+    } = this.props
 
     if (!batTokenAdded) {
       addBatToken()
+    }
+
+    if (hardwareConnect) {
+      this.props.setHardwareConnect(false)
+      this.props.history.push(CONNECT_HARDWARE_ROUTE)
     }
   }
 }
 
 BraveHome.propTypes.batTokenAdded = PropTypes.bool
 BraveHome.propTypes.addBatToken = PropTypes.func
+BraveHome.propTypes.setHardwareConnect = PropTypes.func
 
 module.exports = BraveHome

--- a/brave/ui/app/pages/home/home.container.js
+++ b/brave/ui/app/pages/home/home.container.js
@@ -9,6 +9,7 @@ import {
   unsetMigratedPrivacyMode,
   rejectProviderRequestByOrigin,
   addTokens,
+  setHardwareConnect,
 } from '../../store/actions'
 import batToken from '../../store/bat-token'
 import { getEnvironmentType } from '../../../../../app/scripts/lib/util'
@@ -31,6 +32,7 @@ const mapStateToProps = state => {
     seedPhraseBackedUp,
     tokens,
     batTokenAdded,
+    hardwareConnect,
   } = metamask
   const accountBalance = getCurrentEthBalance(state)
   const { forgottenPassword } = appState
@@ -56,6 +58,7 @@ const mapStateToProps = state => {
     shouldShowSeedPhraseReminder: !seedPhraseBackedUp && (parseInt(accountBalance, 16) > 0 || tokens.length > 0),
     isPopup,
     batTokenAdded,
+    hardwareConnect,
   }
 }
 
@@ -64,6 +67,7 @@ const mapDispatchToProps = (dispatch) => ({
   forceApproveProviderRequestByOrigin: (origin) => dispatch(forceApproveProviderRequestByOrigin(origin)),
   rejectProviderRequestByOrigin: origin => dispatch(rejectProviderRequestByOrigin(origin)),
   addBatToken: () => dispatch(addTokens(batToken)),
+  setHardwareConnect: (value) => dispatch(setHardwareConnect(value)),
 })
 
 export default compose(

--- a/brave/ui/app/pages/routes/index.js
+++ b/brave/ui/app/pages/routes/index.js
@@ -46,6 +46,7 @@ function mapStateToProps (state) {
     providerRequests,
     batTokenAdded,
     rewardsDisclosureAccepted,
+    hardwareConnect,
   } = metamask
   const selected = address || Object.keys(accounts)[0]
 
@@ -92,6 +93,7 @@ function mapStateToProps (state) {
     providerRequests,
     batTokenAdded,
     rewardsDisclosureAccepted,
+    hardwareConnect,
   }
 }
 

--- a/brave/ui/app/store/actions.js
+++ b/brave/ui/app/store/actions.js
@@ -4,6 +4,7 @@ MetaMaskActions.addToken = addToken
 MetaMaskActions.setBatTokenAdded = setBatTokenAdded
 MetaMaskActions.SET_BAT_TOKEN_ADDED = 'SET_BAT_TOKEN_ADDED'
 
+MetaMaskActions.setHardwareConnect = setHardwareConnect
 MetaMaskActions.setRewardsDisclosureAccepted = setRewardsDisclosureAccepted
 
 MetaMaskActions.showModal = showModal
@@ -36,6 +37,20 @@ function setRewardsDisclosureAccepted () {
   return (dispatch) => {
     return new Promise((resolve, reject) => {
       background.setRewardsDisclosureAccepted((err) => {
+        if (err) {
+          dispatch(MetaMaskActions.displayWarning(err.message))
+          return reject(err)
+        }
+        return MetaMaskActions.forceUpdateMetamaskState(dispatch).then(() => resolve())
+      })
+    })
+  }
+}
+
+function setHardwareConnect (value) {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.setHardwareConnect(value, (err) => {
         if (err) {
           dispatch(MetaMaskActions.displayWarning(err.message))
           return reject(err)


### PR DESCRIPTION
Fixes:  https://github.com/brave/brave-browser/issues/6160

This will redirect users who have chosen to connect a Ledger or Trezor device on 
the welcome page to the hardware connection route after creating their initial account.