### PR TITLE
Hiding disabled network buttons

### DIFF
--- a/brave/ui/app/pages/settings/networks-tab/network-form/index.scss
+++ b/brave/ui/app/pages/settings/networks-tab/network-form/index.scss
@@ -1,0 +1,9 @@
+.network-form__footer {
+
+  button {
+
+    &:disabled {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/6161