### PR TITLE
Use translated string for state log

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1594,6 +1594,9 @@
   "status": {
     "message": "Status"
   },
+  "stateLogFileName": {
+    "message": "MetaMask State Logs"
+  },
   "stateLogs": {
     "message": "State Logs"
   },

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -79,7 +79,7 @@ export default class AdvancedTab extends PureComponent {
                   if (err) {
                     displayWarning(t('stateLogError'))
                   } else {
-                    exportAsFile('MetaMask State Logs.json', result)
+                    exportAsFile(`${t('stateLogFileName')}.json`, result)
                   }
                 })
               }}


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/6281

Cherry picked upstream from: https://github.com/MetaMask/metamask-extension/commit/3383eabc9d80b3f60162773a56342649ff0ac301