### PR TITLE
Hiding MM secure logo from dialog

### DIFF
--- a/brave/ui/app/components/app/provider-page-container/index.scss
+++ b/brave/ui/app/components/app/provider-page-container/index.scss
@@ -1,0 +1,3 @@
+.secure-badge {
+  display: none;
+}


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/6534