### PR TITLE
Removing mm secure logo from dapp transaction view

### DIFF
--- a/brave/ui/app/components/app/provider-page-container/index.scss
+++ b/brave/ui/app/components/app/provider-page-container/index.scss
@@ -1,3 +1,8 @@
+.provider-approval-container__content {
+  margin-bottom: 25px;
+}
+
+.provider-approval-container__content
 .secure-badge {
   display: none;
 }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/6534

Follow up to: https://github.com/brave/ethereum-remote-client/pull/86

<img width="509" alt="Screen Shot 2019-10-30 at 10 14 01 PM" src="https://user-images.githubusercontent.com/8732757/67920861-feb2ac80-fb62-11e9-8ec5-37a1f29c9577.png">
