### PR TITLE
Fixing main view overflow

### DIFF
--- a/brave/ui/app/pages/first-time-flow/index.scss
+++ b/brave/ui/app/pages/first-time-flow/index.scss
@@ -1,5 +1,6 @@
 #app-content {
   background: #d5d9dc;
+  overflow-y: hidden;
 }
 
 .first-time-flow {

--- a/brave/ui/app/pages/routes/index.scss
+++ b/brave/ui/app/pages/routes/index.scss
@@ -1,0 +1,3 @@
+.main-container-wrapper {
+  overflow-y: scroll;
+}


### PR DESCRIPTION
Fixes brave/brave-browser#6824 , brave/brave-browser#6528

This allows overflow for the `main-app-container` with our customizations

This can be verified by adding >= 5 to custom tokens and confirming that all controls and assets are still visible