### PR TITLE
Removing 3box control from advanced settings

### DIFF
--- a/brave/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/brave/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -5,4 +5,8 @@ module.exports = class BraveAdvancedTab extends AdvancedTab {
   renderMobileSync () {
     return null
   }
+
+  renderThreeBoxControl () {
+    return null
+  }
 }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/7381

<img width="1044" alt="Screen Shot 2019-12-13 at 2 25 15 PM" src="https://user-images.githubusercontent.com/8732757/70833196-6855e580-1db4-11ea-99ad-521908dcf313.png">
