### PR TITLE
Fixing backup phrase confirmation buttons

### DIFF
--- a/brave/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/index.scss
+++ b/brave/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/index.scss
@@ -1,0 +1,3 @@
+.reveal-seed-phrase__buttons {
+  margin-top: 35px;
+}


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/7417

<img width="1047" alt="Screen Shot 2020-01-03 at 8 55 17 PM" src="https://user-images.githubusercontent.com/8732757/71759533-91c1d880-2e6b-11ea-82aa-6d92e161202d.png">
