### PR TITLE
Fixing overflow issues for seed phrase confirmation and dapp connect

### DIFF
--- a/brave/gulpfile.js/brave-replace-paths.js
+++ b/brave/gulpfile.js/brave-replace-paths.js
@@ -237,6 +237,12 @@ const createBraveReplacePathsTask = () => {
           `'${bravePrefix}app/scripts/controllers/threebox'`
         )
       )
+      .pipe(
+        replace(
+          /'(.*)\/provider-page-container\.component'/gm,
+          `'${bravePrefix}ui/app/components/app/provider-page-container/provider-page-container.component'`
+        )
+      )
       .pipe(gulp.dest(file => file.base))
   })
 }

--- a/brave/ui/app/components/app/provider-page-container/provider-page-container.component.js
+++ b/brave/ui/app/components/app/provider-page-container/provider-page-container.component.js
@@ -1,0 +1,23 @@
+import ProviderPageContainer from '../../../../../../ui/app/components/app/provider-page-container/provider-page-container.component'
+import { getEnvironmentType } from '../../../../../../app/scripts/lib/util'
+import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../../../../app/scripts/lib/enums'
+
+module.exports = class BraveProviderPageContainer extends ProviderPageContainer {
+  componentDidMount () {
+    if (getEnvironmentType(window.location.href) !== ENVIRONMENT_TYPE_NOTIFICATION) {
+      const container = document.querySelector('#app-content')
+      if (container) {
+        container.setAttribute('style', 'overflow-y: scroll')
+      }
+    }
+    super.componentDidMount()
+  }
+
+  componentWillUnmount () {
+    const container = document.querySelector('#app-content')
+    if (container) {
+      container.removeAttribute('style')
+    }
+    super.componentWillUnmount()
+  }
+}

--- a/brave/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/brave/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -6,6 +6,21 @@ import classnames from 'classnames'
 const EMPTY_SEEDS = Array(24).fill(null)
 
 module.exports = class BraveConfirmSeedPhrase extends ConfirmSeedPhrase {
+  componentDidMount () {
+    const container = document.querySelector('#app-content')
+    if (container) {
+      container.setAttribute('style', 'overflow-y: scroll')
+    }
+    super.componentDidMount()
+  }
+
+  componentWillUnmount () {
+    const container = document.querySelector('#app-content')
+    if (container) {
+      container.removeAttribute('style')
+    }
+  }
+
   handleSubmit = async () => {
     const {
       history,


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/7882
Fixes: https://github.com/brave/brave-browser/issues/7045

We initially removed the need for `overflow-y: scroll` when our outer container, housing the Brave Settings header was implemented.

There are two exceptions for this, the connect dapp screen and confirm seed phrase screen.

Unfortunately since this is a top level container that does not receive a selector update when screens change, this can not be targeted with CSS.

A good followup upstream would be to actually make these designs resize, however for now this allows users to scroll without the need to zoom out.