### PR TITLE
Fixing login issues after partial onboarding

### DIFF
--- a/brave/gulpfile.js/brave-replace-paths.js
+++ b/brave/gulpfile.js/brave-replace-paths.js
@@ -243,6 +243,12 @@ const createBraveReplacePathsTask = () => {
           `'${bravePrefix}ui/app/components/app/provider-page-container/provider-page-container.component'`
         )
       )
+      .pipe(
+        replace(
+          /'(.*)\/unlock-page\.container'/gm,
+          `'${bravePrefix}ui/app/pages/unlock-page/unlock-page.container'`
+        )
+      )
       .pipe(gulp.dest(file => file.base))
   })
 }

--- a/brave/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/brave/ui/app/pages/unlock-page/unlock-page.component.js
@@ -1,0 +1,15 @@
+import UnlockPage from '../../../../../ui/app/pages/unlock-page/unlock-page.component'
+
+module.exports = class BraveUnlockPage extends UnlockPage {
+  componentDidMount () {
+    const {
+      isInitialized,
+      completedOnboarding,
+      setCompletedOnboarding,
+    } = this.props
+
+    if (isInitialized && !completedOnboarding) {
+      setCompletedOnboarding()
+    }
+  }
+}

--- a/brave/ui/app/pages/unlock-page/unlock-page.container.js
+++ b/brave/ui/app/pages/unlock-page/unlock-page.container.js
@@ -1,0 +1,68 @@
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
+import { compose } from 'recompose'
+import { getEnvironmentType } from '../../../../../app/scripts/lib/util'
+import { ENVIRONMENT_TYPE_POPUP } from '../../../../../app/scripts/lib/enums'
+import { DEFAULT_ROUTE, RESTORE_VAULT_ROUTE } from '../../../../../ui/app/helpers/constants/routes'
+import {
+  tryUnlockMetamask,
+  forgotPassword,
+  markPasswordForgotten,
+  forceUpdateMetamaskState,
+  showModal,
+  setCompletedOnboarding,
+} from '../../store/actions'
+import UnlockPage from './unlock-page.component'
+
+const mapStateToProps = state => {
+  const { metamask: { isUnlocked, isInitialized, completedOnboarding } } = state
+  return {
+    isUnlocked,
+    isInitialized,
+    completedOnboarding,
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    forgotPassword: () => dispatch(forgotPassword()),
+    tryUnlockMetamask: password => dispatch(tryUnlockMetamask(password)),
+    markPasswordForgotten: () => dispatch(markPasswordForgotten()),
+    forceUpdateMetamaskState: () => forceUpdateMetamaskState(dispatch),
+    showOptInModal: () => dispatch(showModal({ name: 'METAMETRICS_OPT_IN_MODAL' })),
+    setCompletedOnboarding: () => dispatch(setCompletedOnboarding()),
+  }
+}
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const { markPasswordForgotten, tryUnlockMetamask, ...restDispatchProps } = dispatchProps
+  const { history, onSubmit: ownPropsSubmit, ...restOwnProps } = ownProps
+
+  const onImport = () => {
+    markPasswordForgotten()
+    history.push(RESTORE_VAULT_ROUTE)
+
+    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP) {
+      global.platform.openExtensionInBrowser(RESTORE_VAULT_ROUTE)
+    }
+  }
+
+  const onSubmit = async password => {
+    await tryUnlockMetamask(password)
+    history.push(DEFAULT_ROUTE)
+  }
+
+  return {
+    ...stateProps,
+    ...restDispatchProps,
+    ...restOwnProps,
+    onImport,
+    onRestore: onImport,
+    onSubmit: ownPropsSubmit || onSubmit,
+  }
+}
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)
+)(UnlockPage)


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/6442

Issue here was that given our modified onboarding flow, it was possible to initialize vaults/account without setting the `completedOnboarding` flag. This checks for an initialized account without a completed onboarding and sets it so. This will back fix any users who have experienced this issue.

Container needed to be overwritten to merge in extra props