### PR TITLE
Dark mode tweaks

### DIFF
--- a/brave/ui/app/components/ui/theme/dark.scss
+++ b/brave/ui/app/components/ui/theme/dark.scss
@@ -24,6 +24,10 @@
         filter: invert(0.8);
       }
     }
+
+    .__rewards {
+      color: #0096dc;
+    }
   }
 
   .wallet-view {
@@ -73,8 +77,19 @@
   .modal-container,
   .request-signature__container,
   .request-signature__account-item,
-  .network-display__container {
+  .network-display__container,
+  .send-v2__asset-dropdown__list,
+  .transaction-status--submitted {
     background: #282828;
+  }
+
+  .Select-menu-outer,
+  .simple-dropdown__options,
+  .send-v2__asset-dropdown__list {
+
+    * {
+      background: #282828;
+    }
   }
 
   .confirm-page-container-content {
@@ -129,7 +144,9 @@
   }
 
   .confirm-seed-phrase__seed-word,
-  .reveal-seed-phrase__secret-words {
+  .reveal-seed-phrase__secret-words,
+  .ens-input__wrapper__input,
+  .dialog.send__error-dialog.dialog--error {
     color: #000;
   }
 
@@ -141,7 +158,57 @@
     display: none;
   }
 
-  .hw-connect__btn__img {
+  .hw-connect__btn__img,
+  .deposit-ether-modal__logo {
     filter: invert(0.8);
+  }
+
+  .hw-connect__btn.selected {
+    border: 2px solid #00a8ee;
+  }
+
+  .add-token-button__button {
+    color: #00a8ee;
+  }
+
+  .unlock-page__links {
+
+    div {
+      color: #00a8ee;
+    }
+  }
+
+  .gas-price-button-group--small {
+
+    .button-group__button--active {
+      border: 1px solid #3099f2;
+    }
+  }
+
+  .token-list-placeholder,
+  .currency-display-component {
+
+    img {
+      filter: brightness(0) invert(1);
+    }
+  }
+
+  .advanced-tab__fee-chart,
+  .gas-modal-content__info-row-wrapper,
+  .qr-scanner {
+
+    * {
+      color: #000;
+    }
+  }
+
+  .btn-warning,
+  .btn-danger {
+    color: #D73A49;
+    border: 2px solid #D73A49;
+  }
+
+  .provider-approval-visual__check {
+    background: url(/images/provider-approval-check.svg) no-repeat;
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/8018

Note: regarding the cancel button in the create account view, it's actually enabled at all times, not sure why on light it's styled as otherwise

<img width="546" alt="Screen Shot 2020-02-03 at 5 10 23 PM" src="https://user-images.githubusercontent.com/8732757/73702017-a979c000-46a8-11ea-8911-379930c99115.png">
<img width="497" alt="Screen Shot 2020-02-03 at 5 06 42 PM" src="https://user-images.githubusercontent.com/8732757/73702018-a979c000-46a8-11ea-8908-5444a9b16e22.png">
<img width="439" alt="Screen Shot 2020-02-03 at 5 04 44 PM" src="https://user-images.githubusercontent.com/8732757/73702021-aa125680-46a8-11ea-88d9-d756588456f9.png">
<img width="649" alt="Screen Shot 2020-02-03 at 4 57 42 PM" src="https://user-images.githubusercontent.com/8732757/73702022-aa125680-46a8-11ea-9508-439307f661b1.png">
<img width="502" alt="Screen Shot 2020-02-03 at 4 55 27 PM" src="https://user-images.githubusercontent.com/8732757/73702023-aa125680-46a8-11ea-9c34-8e4d42abee70.png">
<img width="526" alt="Screen Shot 2020-02-03 at 4 55 24 PM" src="https://user-images.githubusercontent.com/8732757/73702024-aa125680-46a8-11ea-8749-d2b25eae16de.png">
<img width="404" alt="Screen Shot 2020-02-03 at 4 53 02 PM" src="https://user-images.githubusercontent.com/8732757/73702025-aa125680-46a8-11ea-805b-628c3f11bf28.png">
<img width="529" alt="Screen Shot 2020-02-03 at 4 50 03 PM" src="https://user-images.githubusercontent.com/8732757/73702026-aaaaed00-46a8-11ea-9e20-c329e40dd61a.png">
<img width="498" alt="Screen Shot 2020-02-03 at 4 46 49 PM" src="https://user-images.githubusercontent.com/8732757/73702027-aaaaed00-46a8-11ea-8da4-635e5bb3d2cc.png">
<img width="517" alt="Screen Shot 2020-02-03 at 4 46 17 PM" src="https://user-images.githubusercontent.com/8732757/73702028-aaaaed00-46a8-11ea-896d-7687e14768ba.png">
<img width="345" alt="Screen Shot 2020-02-03 at 4 43 33 PM" src="https://user-images.githubusercontent.com/8732757/73702029-aaaaed00-46a8-11ea-9110-199900c34903.png">
<img width="495" alt="Screen Shot 2020-02-03 at 4 41 42 PM" src="https://user-images.githubusercontent.com/8732757/73702030-aaaaed00-46a8-11ea-94a6-b9682ceec14d.png">
<img width="527" alt="Screen Shot 2020-02-03 at 4 39 06 PM" src="https://user-images.githubusercontent.com/8732757/73702031-ab438380-46a8-11ea-9bad-69d18b81355e.png">
<img width="504" alt="Screen Shot 2020-02-03 at 4 36 51 PM" src="https://user-images.githubusercontent.com/8732757/73702032-ab438380-46a8-11ea-8fc5-5fe7c5055e79.png">
<img width="917" alt="Screen Shot 2020-02-03 at 4 34 11 PM" src="https://user-images.githubusercontent.com/8732757/73702033-ab438380-46a8-11ea-9df7-fde4e04d3c91.png">
<img width="479" alt="Screen Shot 2020-02-03 at 4 30 01 PM" src="https://user-images.githubusercontent.com/8732757/73702034-ab438380-46a8-11ea-9a07-f38957718c01.png">
<img width="429" alt="Screen Shot 2020-02-03 at 4 22 08 PM" src="https://user-images.githubusercontent.com/8732757/73702035-ab438380-46a8-11ea-9b63-07a7fba7e9ff.png">
<img width="697" alt="Screen Shot 2020-02-03 at 4 20 16 PM" src="https://user-images.githubusercontent.com/8732757/73702036-ab438380-46a8-11ea-9c31-bb061bcfb7c1.png">


