### PR TITLE
Making transaction error text visible

### DIFF
--- a/brave/ui/app/components/ui/theme/dark.scss
+++ b/brave/ui/app/components/ui/theme/dark.scss
@@ -146,7 +146,8 @@
   .confirm-seed-phrase__seed-word,
   .reveal-seed-phrase__secret-words,
   .ens-input__wrapper__input,
-  .dialog.send__error-dialog.dialog--error {
+  .dialog.send__error-dialog.dialog--error,
+  .error-message__text {
     color: #000;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-remote-client",
-  "version": "0.1.38",
+  "version": "0.1.40",
   "private": true,
   "scripts": {
     "start": "gulp dev:extension",


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/8018

<img width="343" alt="Screen Shot 2020-02-05 at 2 59 32 PM" src="https://user-images.githubusercontent.com/8732757/73887184-4dd64080-4828-11ea-9b4d-7ed82c62bb11.png">
