### PR TITLE
Version v7.7.7 (#8161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## Current Develop Branch
 
+## 7.7.7 Wed Mar 04 2020
+- [#8162](https://github.com/MetaMask/metamask-extension/pull/8162): Remove invalid Ledger accounts
+- [#8163](https://github.com/MetaMask/metamask-extension/pull/8163): Fix account index check
+
+## 7.7.6 Mon Mar 02 2020
+- [#8154](https://github.com/MetaMask/metamask-extension/pull/8154): Prevent signing from incorrect Ledger account
+
+## 7.7.5 Fri Feb 14 2020
+- [#8053](https://github.com/MetaMask/metamask-extension/pull/8053): Inline the source text not the binary encoding for inpage script
+- [#8049](https://github.com/MetaMask/metamask-extension/pull/8049): Add warning to watchAsset API when editing a known token
+- [#8051](https://github.com/MetaMask/metamask-extension/pull/8051): Update Wyre ETH purchase url
+- [#8059](https://github.com/MetaMask/metamask-extension/pull/8059): Attempt ENS resolution on any valid domain name
+
+## 7.7.4 Wed Jan 29 2020
+- [#7918](https://github.com/MetaMask/metamask-extension/pull/7918): Update data on Approve screen after updating custom spend limit
+- [#7919](https://github.com/MetaMask/metamask-extension/pull/7919): Allow editing max spend limit
+- [#7920](https://github.com/MetaMask/metamask-extension/pull/7920): Validate custom spend limit
+- [#7944](https://github.com/MetaMask/metamask-extension/pull/7944): Only resolve ENS on mainnet
+- [#7954](https://github.com/MetaMask/metamask-extension/pull/7954): Update ENS registry addresses
+
+## 7.7.3 Fri Jan 24 2020
+- [#7894](https://github.com/MetaMask/metamask-extension/pull/7894): Update GABA dependency version
+- [#7901](https://github.com/MetaMask/metamask-extension/pull/7901): Use eth-contract-metadata@1.12.1
+- [#7910](https://github.com/MetaMask/metamask-extension/pull/7910): Fixing broken JSON import help link
+
+## 7.7.2 Fri Jan 10 2020
+- [#7753](https://github.com/MetaMask/metamask-extension/pull/7753): Fix gas estimate for tokens
+- [#7473](https://github.com/MetaMask/metamask-extension/pull/7473): Fix transaction order on transaction confirmation screen
+
+## 7.7.1 Wed Dec 04 2019
+- [#7488](https://github.com/MetaMask/metamask-extension/pull/7488): Fix text overlap when expanding transaction
+- [#7491](https://github.com/MetaMask/metamask-extension/pull/7491): Update gas when asset is changed on send screen
+- [#7500](https://github.com/MetaMask/metamask-extension/pull/7500): Remove unused onClick prop from Dropdown component
+- [#7502](https://github.com/MetaMask/metamask-extension/pull/7502): Fix chainId for non standard networks
+- [#7519](https://github.com/MetaMask/metamask-extension/pull/7519): Fixing hardware connect error display
+- [#7501](https://github.com/MetaMask/metamask-extension/pull/7501): Fix accessibility of first-time-flow terms checkboxes
+- [#7579](https://github.com/MetaMask/metamask-extension/pull/7579): Prevent Maker migration dismissal timeout state from being overwritten
+- [#7581](https://github.com/MetaMask/metamask-extension/pull/7581): Persist Maker migration dismissal timeout
+- [#7484](https://github.com/MetaMask/metamask-extension/pull/7484): Ensure transactions are shown in the order they are received
+- [#7604](https://github.com/MetaMask/metamask-extension/pull/7604): Process URL fragment for ens-ipfs redirects
+- [#7628](https://github.com/MetaMask/metamask-extension/pull/7628): Fix typo that resulted in degrated account menu performance
+- [#7558](https://github.com/MetaMask/metamask-extension/pull/7558): Use localized messages for NotificationModal buttons
+
+## 7.7.0 Thu Nov 28 2019 [WITHDRAWN]
+- [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Connect distinct accounts per site
+- [#7480](https://github.com/MetaMask/metamask-extension/pull/7480): Fixed link on root README.md
+- [#7482](https://github.com/MetaMask/metamask-extension/pull/7482): Update Wyre ETH purchase url
+- [#7484](https://github.com/MetaMask/metamask-extension/pull/7484): Ensure transactions are shown in the order they are received
+- [#7491](https://github.com/MetaMask/metamask-extension/pull/7491): Update gas when token is changed on the send screen
+- [#7501](https://github.com/MetaMask/metamask-extension/pull/7501): Fix accessibility of first-time-flow terms checkboxes
+- [#7502](https://github.com/MetaMask/metamask-extension/pull/7502): Fix chainId for non standard networks
+- [#7579](https://github.com/MetaMask/metamask-extension/pull/7579): Fix timing of DAI migration notifications after dismissal
+- [#7519](https://github.com/MetaMask/metamask-extension/pull/7519): Fixing hardware connect error display
+- [#7558](https://github.com/MetaMask/metamask-extension/pull/7558): Use localized messages for NotificationModal buttons
+- [#7488](https://github.com/MetaMask/metamask-extension/pull/7488): Fix text overlap when expanding transaction
+
 ## 7.6.1 Tue Nov 19 2019
 - [#7475](https://github.com/MetaMask/metamask-extension/pull/7475): Add 'Remind Me Later' to the Maker notification
 - [#7436](https://github.com/MetaMask/metamask-extension/pull/7436): Add additional rpcUrl verification

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "7.6.1",
+  "version": "7.7.7",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "__MSG_appDescription__",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "3box": "^1.10.2",
     "@babel/runtime": "^7.5.5",
     "@material-ui/core": "1.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "^0.2.2",
+    "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@sentry/browser": "^4.1.1",
     "@zxing/library": "^0.8.0",
     "abi-decoder": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,10 +1992,10 @@
     scroll "^2.0.3"
     warning "^3.0.0"
 
-"@metamask/eth-ledger-bridge-keyring@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.2.2.tgz#f75dd45edf17c48b02e49a96b3413e6abf14b7ef"
-  integrity sha512-c1Gfn01qIqNikx8eFz1jq2KU9Vcfpgkp62v8kYgiWebwkyxuzBKlDWMoC3JCwAV5ezl05M6MQi1EAwrcsIbUOA==
+"@metamask/eth-ledger-bridge-keyring@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.2.6.tgz#2721c118a5eeb3685d372d0258f2a3b03dd01315"
+  integrity sha512-7OtX24lHSCioFZM+x4ZCsndT1wkI7cf8+ua3UntYqHFSRu/SDf6xVNBuD8isvWidNbVdcJKhfJuO3vFCDNsPBw==
   dependencies:
     eth-sig-util "^1.4.2"
     ethereumjs-tx "^1.3.4"


### PR DESCRIPTION
Brave Note: This also includes previously excluded upstream changelog updates

* Version v7.7.7
* Update `@metamask/eth-ledger-bridge-keyring` (#8162)
* Update `@metamask/eth-ledger-bridge-keyring`

The Ledger keyring has been updated to ensure that any stale BIP44
accounts created prior to v7.7.6 of the extension are discarded when
the extension starts. Any attempts to sign with these accounts would
have failed; they needed to be re-added regardless.

* Update changelog
* Fix Ledger account index check for account zero (#8163)

Update Ledger keyring to fix bug when trying to sign with account 0