### PR TITLE
Fixing signed type data styles on dark mode

### DIFF
--- a/brave/ui/app/components/ui/theme/dark.scss
+++ b/brave/ui/app/components/ui/theme/dark.scss
@@ -229,4 +229,15 @@
   .provider-approval-visual__check {
     background: url(/images/provider-approval-check.svg) no-repeat;
   }
+
+  .signature-request-message {
+
+    &--root {
+      background: #282828;
+    }
+  }
+
+  .signature-request.page-container {
+    background: #282828;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/10769

<img width="361" alt="Screen Shot 2020-07-16 at 3 13 38 AM" src="https://user-images.githubusercontent.com/8732757/87659410-62413200-c712-11ea-8ccf-058a40ccc59a.png">
