### PR TITLE
Show browser action button

### DIFF
--- a/brave/gulpfile.js/brave-manifest.js
+++ b/brave/gulpfile.js/brave-manifest.js
@@ -6,8 +6,6 @@ const createBraveManifestTask = () =>
     return gulp.src('./dist/brave/manifest.json')
       .pipe(jsoneditor(function (json) {
         delete json.applications
-        delete json.browser_action
-        delete json.commands._execute_browser_action
         json.name = 'Crypto Wallets'
         json.author = 'https://brave.com'
         json.key = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl7ZLkqbq8pHRcYANANXmhGKZKHsruBqS0ssf8aI5R5E5FBaWui73FPWMj0g4eggrJeSfF/x/nIIq3Z24Joq1ULuWtheQjbOwqj0yL2ZaxMA6rc5cW2OmGZ0aNXMFclusXftJmwpb/pztHzw55yv8BfJr873HOxtlW2MP1VvSFQjigsbJedlkoS4SKC0U3j8/mjAYR0+lpmBtPitObnYnM5qmtrlg2hgm+sqAon9WKj9nDIjPpXJaCs7kpVl7oQOoYpv47ZT1tnu0o03AL3RZbxPU1N04X3JN6nC+g4gaCgiLkZ+dD79yIt7Il0+vSKuJ+EGySVmv6czOI5eJYezWXwIDAQAB'

--- a/brave/lib/extensionizer/index.js
+++ b/brave/lib/extensionizer/index.js
@@ -1,10 +1,5 @@
 const extension = require('extensionizer')
 
-extension.browserAction = {
-  setBadgeText: (_opts) => { /* no-op */ },
-  setBadgeBackgroundColor: (_opts) => { /* no-op */ },
-}
-
 extension.runtime.onInstalled = {
   addListener: (_reason) => { /* no-op */ },
 }

--- a/brave/ui/app/ducks/metamask/metamask.js
+++ b/brave/ui/app/ducks/metamask/metamask.js
@@ -11,7 +11,7 @@ module.exports = function (state, action) {
   switch (action.type) {
     case actions.SET_BAT_TOKEN_ADDED:
       return extend(newState, {
-        batTokenAdded: action.value,
+        batTokenAdded: true,
       })
     default:
       return newState

--- a/brave/ui/app/pages/home/home.container.js
+++ b/brave/ui/app/pages/home/home.container.js
@@ -6,6 +6,7 @@ import { unconfirmedTransactionsCountSelector } from '../../../../../ui/app/sele
 import { getCurrentEthBalance } from '../../../../../ui/app/selectors/selectors'
 import {
   addTokens,
+  setBatTokenAdded,
   setHardwareConnect,
   restoreFromThreeBox,
   turnThreeBoxSyncingOn,
@@ -71,7 +72,10 @@ const mapDispatchToProps = (dispatch) => ({
   },
   restoreFromThreeBox: (address) => dispatch(restoreFromThreeBox(address)),
   setShowRestorePromptToFalse: () => dispatch(setShowRestorePromptToFalse()),
-  addBatToken: () => dispatch(addTokens(batToken)),
+  addBatToken: () => {
+    dispatch(addTokens(batToken))
+    dispatch(setBatTokenAdded())
+  },
   setHardwareConnect: (value) => dispatch(setHardwareConnect(value)),
 })
 

--- a/brave/ui/app/store/actions.js
+++ b/brave/ui/app/store/actions.js
@@ -27,8 +27,7 @@ function setBatTokenAdded () {
       }
     })
     dispatch({
-      type: MetaMaskActions.SET_BAT_TOKEN_ADDED,
-      value: true,
+      type: MetaMaskActions.SET_BAT_TOKEN_ADDED
     })
   }
 }


### PR DESCRIPTION
Fix: https://github.com/brave/brave-browser/issues/7497

Removing the code which hides the browser action for Crypto Wallets since:
- We're now more opt-in
- We lazy load, so it'll only really be there when it's loaded
- People miss it and feel like we give a sub-par experience without it
