### PR TITLE
Using verifyPassword method for private key export

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1681,9 +1681,9 @@ export function exportAccount (password, address) {
   return function (dispatch) {
     dispatch(showLoadingIndication())
 
-    log.debug(`background.submitPassword`)
+    log.debug(`background.verifyPassword`)
     return new Promise((resolve, reject) => {
-      background.submitPassword(password, function (err) {
+      background.verifyPassword(password, function (err) {
         if (err) {
           log.error('Error in submitting password.')
           dispatch(hideLoadingIndication())


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/11357

This is essentially the same thing that fixed the same behavior with Revealing Seed Phrase