### PR TITLE
Clearing password warning after incorrect password for key export

### DIFF
--- a/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
+++ b/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
@@ -26,12 +26,19 @@ export default class ExportPrivateKeyModal extends Component {
     showAccountDetailModal: PropTypes.func.isRequired,
     hideModal: PropTypes.func.isRequired,
     previousModalState: PropTypes.string,
+    clearWarning: PropTypes.func,
   }
 
   state = {
     password: '',
     privateKey: null,
     showWarning: true,
+  }
+
+  componentWillUnmount () {
+    if (this.state.showWarning) {
+      this.props.clearWarning()
+    }
   }
 
   exportAccountAndGetPrivateKey = (password, address) => {

--- a/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.container.js
+++ b/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.container.js
@@ -32,6 +32,7 @@ function mapDispatchToProps (dispatch) {
     },
     showAccountDetailModal: () => dispatch(showModal({ name: 'ACCOUNT_DETAILS' })),
     hideModal: () => dispatch(hideModal()),
+    clearWarning: () => dispatch(hideWarning()),
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/11671
Fixes: https://github.com/brave/brave-browser/issues/11672