### PR TITLE
Cancels permissions requests when closing a locked connection popup

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -277,9 +277,9 @@ export class PermissionsController {
       return
     }
 
-    this.pendingApprovals.forEach(async (_approval, id) => {
+    for (const [id] of this.pendingApprovals) {
       await this.rejectPermissionsRequest(id)
-    })
+    }
   }
 
   /**

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -268,6 +268,21 @@ export class PermissionsController {
   }
 
   /**
+   * Rejects all pending permissions requests
+   * (Used in the event of closing a locked request window)
+   */
+  async rejectAllPermissionsRequests () {
+    if (!this.pendingApprovals.size) {
+      log.debug(`No permissions request in queue`)
+      return
+    }
+
+    this.pendingApprovals.forEach(async (_approval, id) => {
+      await this.rejectPermissionsRequest(id)
+    })
+  }
+
+  /**
    * Expose an account to the given origin. Changes the eth_accounts
    * permissions and emits accountsChanged.
    *

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -566,6 +566,7 @@ export default class MetamaskController extends EventEmitter {
       clearPermissions: permissionsController.clearPermissions.bind(permissionsController),
       getApprovedAccounts: nodeify(permissionsController.getAccounts, permissionsController),
       rejectPermissionsRequest: nodeify(permissionsController.rejectPermissionsRequest, permissionsController),
+      rejectAllPermissionsRequests: nodeify(permissionsController.rejectAllPermissionsRequests, permissionsController),
       removePermissionsFor: permissionsController.removePermissionsFor.bind(permissionsController),
       addPermittedAccount: nodeify(permissionsController.addPermittedAccount, permissionsController),
       removePermittedAccount: nodeify(permissionsController.removePermittedAccount, permissionsController),

--- a/ui/app/pages/unlock-page/unlock-page.container.js
+++ b/ui/app/pages/unlock-page/unlock-page.container.js
@@ -2,20 +2,24 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { compose } from 'redux'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
-import { ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
+import { ENVIRONMENT_TYPE_NOTIFICATION, ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
 import { DEFAULT_ROUTE, RESTORE_VAULT_ROUTE } from '../../helpers/constants/routes'
 import {
   tryUnlockMetamask,
   forgotPassword,
   markPasswordForgotten,
   forceUpdateMetamaskState,
+  rejectAllPermissionsRequests,
   showModal,
 } from '../../store/actions'
 import UnlockPage from './unlock-page.component'
 
 const mapStateToProps = (state) => {
   const { metamask: { isUnlocked } } = state
+  const isNotification = getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION
+
   return {
+    isNotification,
     isUnlocked,
   }
 }
@@ -27,6 +31,7 @@ const mapDispatchToProps = (dispatch) => {
     markPasswordForgotten: () => dispatch(markPasswordForgotten()),
     forceUpdateMetamaskState: () => forceUpdateMetamaskState(dispatch),
     showOptInModal: () => dispatch(showModal({ name: 'METAMETRICS_OPT_IN_MODAL' })),
+    rejectAllPermissionsRequests: () => dispatch(rejectAllPermissionsRequests()),
   }
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2097,6 +2097,25 @@ export function rejectPermissionsRequest (requestId) {
 }
 
 /**
+ * Rejects all pending permissions requests
+ */
+export function rejectAllPermissionsRequests () {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.rejectAllPermissionsRequests((err) => {
+        if (err) {
+          dispatch(displayWarning(err.message))
+          return reject(err)
+        }
+        return forceUpdateMetamaskState(dispatch)
+          .then(resolve)
+          .catch(reject)
+      })
+    })
+  }
+}
+
+/**
  * Clears the given permissions for the given origin.
  */
 export function removePermissionsFor (domains) {


### PR DESCRIPTION
Fixes brave/brave-browser#11764

This employs a similar mechanism to the `PermissionConnect` component, which cancels its pending request on window close. However, we should actually clear all pending requests when the locked window is closed, as new popups will not open when stacking requests while locked. It will focus on the already open popup.