### PR TITLE
Fixing hide token modal on dark theme

### DIFF
--- a/ui/app/components/app/dark.scss
+++ b/ui/app/components/app/dark.scss
@@ -337,4 +337,13 @@
       background: rgba(0, 0, 0, 0.03);
     }
   }
+
+  .hide-token-confirmation {
+    border-radius: 0;
+    background: #282a2c;
+  }
+
+  .token-options__button {
+    border: none;
+  }
 }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/12290