### PR TITLE
Disabling comments for sourcemap files

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -218,7 +218,7 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
           .pipe(sourcemaps.write())
       } else {
         buildStream = buildStream
-          .pipe(sourcemaps.write('../sourcemaps'))
+          .pipe(sourcemaps.write('../sourcemaps', { addComment: false }))
       }
 
       // write completed bundles


### PR DESCRIPTION
Fixes brave/brave-browser#8281
Ref: https://github.com/gulp-sourcemaps/gulp-sourcemaps#write-options