### PR TITLE
Adding warning when sending a token to its own contract address

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1762,6 +1762,9 @@
   "braveSettings": {
     "message": "Brave Settings"
   },
+  "contractErrorMessage": {
+    "message": "Warning: You are about to send this asset to its own smart contract. You probably don't mean to do this, as it will likely render the asset unrecoverable."
+  },
   "cryptoWalletsDisclosureOne": {
     "message": "Crypto Wallets lets you work with cryptocurrency and related assets in Brave. Crypto Wallets supports Ethereum tokens like ETH and BAT, as well as collectibles, and lets you work with Ðapps and other smart contracts. All this is meant for people who are familiar with Ethereum and other blockchain systems — or are excited to learn."
   },

--- a/ui/app/components/app/dark.scss
+++ b/ui/app/components/app/dark.scss
@@ -346,4 +346,10 @@
   .token-options__button {
     border: none;
   }
+
+  .contract-error-dialog {
+    .error__dialog {
+      background: #b92534;
+    }
+  }
 }

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -1107,3 +1107,7 @@
 .sliders-icon {
   color: $primary-blue;
 }
+
+.contract-error-dialog {
+  padding: 16px;
+}

--- a/ui/app/pages/send/send-content/send-content.component.js
+++ b/ui/app/pages/send/send-content/send-content.component.js
@@ -19,6 +19,7 @@ export default class SendContent extends Component {
     showHexData: PropTypes.bool,
     contact: PropTypes.object,
     isOwnedAccount: PropTypes.bool,
+    isContractAddress: PropTypes.bool,
   }
 
   updateGas = (updateData) => this.props.updateGas(updateData)
@@ -27,6 +28,7 @@ export default class SendContent extends Component {
     return (
       <PageContainerContent>
         <div className="send-v2__form">
+          { this.maybeRenderContractWarning() }
           { this.maybeRenderAddContact() }
           <SendAssetRow />
           <SendAmountRow updateGas={this.updateGas} />
@@ -40,6 +42,27 @@ export default class SendContent extends Component {
           }
         </div>
       </PageContainerContent>
+    )
+  }
+
+  maybeRenderContractWarning () {
+    const { t } = this.context
+    const { isContractAddress } = this.props
+
+    if (!isContractAddress) {
+      return
+    }
+
+    return (
+      <div className="contract-error-dialog">
+        <Dialog
+          type="error"
+          className="error__dialog"
+          onClick={undefined}
+        >
+          {t('contractErrorMessage')}
+        </Dialog>
+      </div>
     )
   }
 

--- a/ui/app/pages/send/send-content/send-content.container.js
+++ b/ui/app/pages/send/send-content/send-content.container.js
@@ -4,6 +4,7 @@ import {
   getSendTo,
   accountsWithSendEtherInfoSelector,
   getAddressBookEntry,
+  getIsContractAddress,
 } from '../../../selectors'
 
 import * as actions from '../../../store/actions'
@@ -15,6 +16,7 @@ function mapStateToProps (state) {
     isOwnedAccount: !!ownedAccounts.find(({ address }) => address.toLowerCase() === to.toLowerCase()),
     contact: getAddressBookEntry(state, to),
     to,
+    isContractAddress: getIsContractAddress(state),
   }
 }
 

--- a/ui/app/pages/send/send-content/tests/send-content-component.test.js
+++ b/ui/app/pages/send/send-content/tests/send-content-component.test.js
@@ -75,6 +75,26 @@ describe('SendContent Component', function () {
       assert(PageContainerContentChild.childAt(2).is(SendGasRow), 'row[3] should be SendGasRow')
       assert.equal(PageContainerContentChild.childAt(3).exists(), false)
     })
+
+    it('should render contract warning when sending a token to its own address', function () {
+      wrapper.setProps({
+        showHexData: false,
+        isOwnedAccount: true,
+        isContractAddress: true,
+      })
+      const PageContainerContentChild = wrapper.find(PageContainerContent).children()
+      assert(PageContainerContentChild.childAt(0).is('.contract-error-dialog'), 'row[0] should be contract error dialog')
+    })
+
+    it('should not render contract warning when sending a token to an appropriate address', function () {
+      wrapper.setProps({
+        showHexData: false,
+        isOwnedAccount: true,
+        isContractAddress: false,
+      })
+      const PageContainerContentChild = wrapper.find(PageContainerContent).children()
+      assert(PageContainerContentChild.childAt(0).is(SendAssetRow), 'row[0] should be SendAssetRow')
+    })
   })
 
   it('should not render the asset dropdown if token length is 0 ', function () {

--- a/ui/app/selectors/send.js
+++ b/ui/app/selectors/send.js
@@ -165,3 +165,14 @@ export function getTitleKey (state) {
 export function isSendFormInError (state) {
   return Object.values(getSendErrors(state)).some((n) => n)
 }
+
+export function getIsContractAddress (state) {
+  const sendTo = getSendTo(state)
+  const sendTokenAddress = getSendTokenAddress(state)
+
+  if (!sendTokenAddress) {
+    return false
+  }
+
+  return sendTo.toLowerCase() === sendTokenAddress.toLowerCase()
+}

--- a/ui/app/selectors/tests/send.test.js
+++ b/ui/app/selectors/tests/send.test.js
@@ -33,6 +33,7 @@ import {
   getGasButtonGroupShown,
   getTitleKey,
   isSendFormInError,
+  getIsContractAddress,
 } from '../send'
 import mockState from './send-selectors-test-data'
 
@@ -194,6 +195,60 @@ describe('send selectors', function () {
           decimals: 4,
           symbol: 'DEF',
         },
+      )
+    })
+  })
+
+  describe('getIsContractAddress()', function () {
+    it('should return true when the send address is the same as the selected token\'s contract address', function () {
+      assert.equal(
+        getIsContractAddress({
+          metamask: {
+            send: {
+              token: {
+                address: '0x8d6b81208414189a58339873ab429b6c47ab92d3',
+                decimals: 4,
+                symbol: 'DEF',
+              },
+              to: '0x8d6b81208414189a58339873ab429b6c47ab92d3',
+            },
+          },
+        }),
+        true,
+      )
+    })
+    it('should return true when the send address is the same as the selected token\'s contract address, capitalized input', function () {
+      assert.equal(
+        getIsContractAddress({
+          metamask: {
+            send: {
+              token: {
+                address: '0x8d6b81208414189a58339873ab429b6c47ab92d3',
+                decimals: 4,
+                symbol: 'DEF',
+              },
+              to: '0X8D6B81208414189A58339873AB429B6C47AB92D3',
+            },
+          },
+        }),
+        true,
+      )
+    })
+    it('should return false when the recipient address differs', function () {
+      assert.equal(
+        getIsContractAddress({
+          metamask: {
+            send: {
+              token: {
+                address: '0x8d6b81208414189a58339873ab429b6c47ab92d3',
+                decimals: 4,
+                symbol: 'DEF',
+              },
+              to: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+            },
+          },
+        }),
+        false,
       )
     })
   })


### PR DESCRIPTION
Fixes brave/brave-browser#12959