### PR TITLE
Fixing network warning visiblity (Dark theme)

### DIFF
--- a/ui/app/components/app/dark.scss
+++ b/ui/app/components/app/dark.scss
@@ -168,7 +168,8 @@
   .reveal-seed-phrase__secret-words,
   .ens-input__wrapper__input,
   .dialog.send__error-dialog.dialog--error,
-  .error-message__text {
+  .error-message__text,
+  .networks-tab__network-form-row--warning {
     color: #000;
   }
 


### PR DESCRIPTION
Fixes brave/brave-browser#14004

<img width="1014" alt="Screen Shot 2021-02-05 at 9 53 25 AM" src="https://user-images.githubusercontent.com/8732757/107064887-4f1eae00-6799-11eb-94de-f9dc52bc21f0.png">
