### PR TITLE
Reduce infura usage by pausing token-tracker and account-tracker when not active

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -295,6 +295,9 @@ function setupController (initState, initLangCode) {
   //
   extension.runtime.onConnect.addListener(connectRemote)
   extension.runtime.onConnectExternal.addListener(connectExternal)
+  extension.tabs.onActivated.addListener(onTabActivated)
+  extension.tabs.onUpdated.addListener(onTabUpdated)
+  extension.windows.onFocusChanged.addListener(onWindowFocusChanged)
 
   const metamaskInternalProcessHash = {
     [ENVIRONMENT_TYPE_POPUP]: true,
@@ -338,9 +341,11 @@ function setupController (initState, initLangCode) {
 
       if (processName === ENVIRONMENT_TYPE_POPUP) {
         popupIsOpen = true
+        controller.isClientActivated = true
 
         endOfStream(portStream, () => {
           popupIsOpen = false
+          controller.isClientActivated = false
           controller.isClientOpen = isClientOpenStatus()
         })
       }
@@ -383,6 +388,40 @@ function setupController (initState, initLangCode) {
   function connectExternal (remotePort) {
     const portStream = new PortStream(remotePort)
     controller.setupUntrustedCommunication(portStream, remotePort.sender)
+  }
+
+  function onTabActivated (activeInfo) {
+    const activated = Object.keys(openMetamaskTabsIDs).includes(activeInfo.tabId.toString())
+    if (controller.isClientActivated !== activated) {
+      controller.isClientActivated = activated
+    }
+  }
+
+  function onTabUpdated (_tabId, _changeInfo, tab) {
+    if (tab.active) {
+      const activated = Object.keys(openMetamaskTabsIDs).includes(tab.id.toString())
+      if (controller.isClientActivated !== activated) {
+        controller.isClientActivated = activated
+      }
+    }
+  }
+
+  function onWindowFocusChanged (windowId) {
+    if (windowId === extension.windows.WINDOW_ID_NONE) {
+      if (controller.isClientActivated) {
+        controller.isClientActivated = false
+      }
+      return
+    }
+    extension.tabs.query({
+      active: true,
+      windowId,
+    }, (tabs) => {
+      const activated = Boolean(tabs.find((tab) => openMetamaskTabsIDs[tab.id]))
+      if (controller.isClientActivated !== activated) {
+        controller.isClientActivated = activated
+      }
+    })
   }
 
   //

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2069,6 +2069,25 @@ export default class MetamaskController extends EventEmitter {
     this.detectTokensController.isOpen = open
   }
 
+  get isClientActivated () {
+    return this._isClientActivated
+  }
+
+  set isClientActivated (activated) {
+    // Make sure this is a real update
+    if (this._isClientActivated === activated) {
+      return
+    }
+    this._isClientActivated = activated
+    if (activated) {
+      log.trace('Starting account tracker because client is active')
+      this.accountTracker.start()
+    } else {
+      log.trace('Stopping account tracker because client is not active')
+      this.accountTracker.stop()
+    }
+  }
+
   /**
   * Creates RPC engine middleware for processing eth_signTypedData requests
   *

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/controllers": "^2.0.5",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
-    "@metamask/eth-token-tracker": "^3.0.0",
+    "@brave/eth-token-tracker": "^3.0.0",
     "@metamask/etherscan-link": "^1.1.0",
     "@metamask/inpage-provider": "^6.1.0",
     "@popperjs/core": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "json-rpc-middleware-stream": "^2.1.1",
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.19",
-    "loglevel": "^1.4.1",
+    "loglevel": "^1.7.1",
     "luxon": "^1.23.0",
     "multihashes": "^0.4.12",
     "nanoid": "^2.1.6",

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -301,6 +301,29 @@ describe('MetaMaskController', function () {
     })
   })
 
+
+  describe('#isClientActivated', function () {
+    it('should stop account tracker', async function () {
+      let stopped = false
+      sinon.stub(metamaskController.accountTracker, 'stop').callsFake(() => {
+        stopped = true
+      })
+
+      metamaskController.isClientActivated = false
+      assert(stopped)
+    })
+
+    it('should start account tracker', async function () {
+      let stopped = true
+      sinon.stub(metamaskController.accountTracker, 'start').callsFake(() => {
+        stopped = false
+      })
+
+      metamaskController.isClientActivated = true
+      assert(!stopped)
+    })
+  })
+
   describe('#getApi', function () {
     it('getState', function (done) {
       let state

--- a/ui/app/hooks/useTokenTracker.js
+++ b/ui/app/hooks/useTokenTracker.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import TokenTracker from '@metamask/eth-token-tracker'
+import TokenTracker from '@brave/eth-token-tracker'
 import { useSelector } from 'react-redux'
 import { getCurrentNetwork, getSelectedAddress } from '../selectors'
 

--- a/ui/app/hooks/useTokenTracker.js
+++ b/ui/app/hooks/useTokenTracker.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import TokenTracker from '@brave/eth-token-tracker'
 import { useSelector } from 'react-redux'
 import { getCurrentNetwork, getSelectedAddress } from '../selectors'
-
+import log from 'loglevel'
 
 export function useTokenTracker (tokens) {
   const network = useSelector(getCurrentNetwork)
@@ -12,6 +12,7 @@ export function useTokenTracker (tokens) {
   const [tokensWithBalances, setTokensWithBalances] = useState([])
   const [error, setError] = useState(null)
   const tokenTracker = useRef(null)
+  const accountTrackerStarted = useRef(false)
 
   const updateBalances = useCallback((tokensWithBalances) => {
     setTokensWithBalances(tokensWithBalances)
@@ -42,10 +43,30 @@ export function useTokenTracker (tokens) {
       tokens: tokenList,
       pollingInterval: (16 * 1000),
     })
+    accountTrackerStarted.current = true
 
     tokenTracker.current.on('update', updateBalances)
     tokenTracker.current.on('error', showError)
     tokenTracker.current.updateBalances()
+
+    window.addEventListener('focus', () => {
+      if (tokenTracker.current) {
+        log.debug('Enabling tokenTracker because tab is focused')
+        if (!accountTrackerStarted.current) {
+          accountTrackerStarted.current = true
+          tokenTracker.current.start()
+        }
+      }
+    })
+    window.addEventListener('blur', () => {
+      if (tokenTracker.current) {
+        log.debug('Disabling tokenTracker because tab is blured')
+        if (accountTrackerStarted.current) {
+          accountTrackerStarted.current = false
+          tokenTracker.current.stop()
+        }
+      }
+    })
   }, [updateBalances, showError, teardownTracker])
 
   // Effect to remove the tracker when the component is removed from DOM
@@ -81,7 +102,9 @@ export function useTokenTracker (tokens) {
       updateBalances([])
     }
 
-    buildTracker(userAddress, tokens)
+    if (!tokenTracker.current) {
+      buildTracker(userAddress, tokens)
+    }
   }, [userAddress, teardownTracker, network, tokens, updateBalances, buildTracker])
 
   return { loading, tokensWithBalances, error }

--- a/ui/index.js
+++ b/ui/index.js
@@ -20,7 +20,7 @@ import {
   getUnconnectedAccountAlertShown,
 } from './app/ducks/metamask/metamask'
 
-log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn')
+log.setDefaultLevel(global.METAMASK_DEBUG ? 'debug' : 'warn')
 
 export default function launchMetamaskUi (opts, cb) {
   const { backgroundConnection } = opts

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,6 +1095,19 @@
     obs-store "^4.0.3"
     promise-filter "1.1.0"
 
+"@brave/eth-token-tracker@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@brave/eth-token-tracker/-/eth-token-tracker-3.1.0.tgz#fa4a4c1b7711c15dc20906ebb5b0dfbabf09acd3"
+  integrity sha512-MK6CyzkZYcSu/FAIoyPDVu+H3I5ozjJ/dGcnk4V/XU4MOMfb7gaSb0qHLlKX9cI6Kg2aQhe5Yx0yqD6KZaLFhg==
+  dependencies:
+    deep-equal "^1.1.0"
+    eth-block-tracker "^4.4.2"
+    ethjs "^0.3.6"
+    ethjs-contract "^0.2.1"
+    ethjs-query "^0.3.7"
+    human-standard-token-abi "^1.0.2"
+    safe-event-emitter "^1.0.1"
+
 "@chromaui/localtunnel@1.10.1":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@chromaui/localtunnel/-/localtunnel-1.10.1.tgz#34da7dab7055a16b1b9034a9eb7e3054ebec4b98"
@@ -1458,19 +1471,6 @@
     ethereumjs-util "^5.1.5"
     events "^2.0.0"
     hdkey "0.8.0"
-
-"@metamask/eth-token-tracker@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-token-tracker/-/eth-token-tracker-3.0.0.tgz#16ad4820abd6603d745c8cdaf7c5a9ae60e6db02"
-  integrity sha512-UxYkmEMrUYb8wzsqEY8x6QeiW2955guR/aaalqfElI2rlDyvKJ1lIaAiT7y642vcqoyIGhqYG2aejeHDpifMbA==
-  dependencies:
-    deep-equal "^1.1.0"
-    eth-block-tracker "^4.4.2"
-    ethjs "^0.3.6"
-    ethjs-contract "^0.2.1"
-    ethjs-query "^0.3.7"
-    human-standard-token-abi "^1.0.2"
-    safe-event-emitter "^1.0.1"
 
 "@metamask/etherscan-link@^1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15587,7 +15587,7 @@ logalot@^2.0.0:
     figures "^1.3.5"
     squeak "^1.0.0"
 
-loglevel@^1.4.1, loglevel@^1.5.0:
+loglevel@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.0.tgz#ae0caa561111498c5ba13723d6fb631d24003934"
   integrity sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ=
@@ -15596,6 +15596,11 @@ loglevel@^1.6.1, loglevel@^1.6.7:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
+
+loglevel@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
+  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
 long@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
The fix is mainly around pausing the account tracker and token tracker when the window is not focused and the browser action pane is not open. 

Fix https://github.com/brave/brave-browser/issues/13777

If you set your log level to trace you can see logs of when things are paused and not paused.

This is easiest to review 1 commit at a time.