### PR TITLE
Remove description since it's not translating

### DIFF
--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "manifest_version": 2,
   "author": "https://brave.com",
-  "description": "__MSG_appDescription__",
+  "description": "",
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
For the way we're loading, it is not translating the extension description, see here: https://github.com/brave/brave-browser/issues/14070