### PR TITLE
fix: faucet not showing in wallet issue #14565

### DIFF
--- a/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
+++ b/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
@@ -76,9 +76,9 @@ export default class DepositEtherModal extends Component {
 
   render () {
     const { network, toFaucet } = this.props
-
-    const isTestNetwork = ['3', '4', '5', '42'].find((n) => n === network)
     const networkName = getNetworkDisplayName(network)
+    const isTestNetwork = [3, 4, 5, 42].find((n) => n === Number(network))
+
 
     return (
       <div
@@ -123,7 +123,7 @@ export default class DepositEtherModal extends Component {
               title: this.context.t('testFaucet'),
               text: this.faucetRowText(networkName),
               buttonLabel: this.context.t('getEther'),
-              onButtonClick: () => toFaucet(network),
+              onButtonClick: () => toFaucet(Number(network).toString()),
               hide: !isTestNetwork,
             })}
           </div>


### PR DESCRIPTION
Fix <https://github.com/brave/brave-browser/issues/14565>

isTestNetwork and toFaucet are expecting to be passed the networkID but were being passed the chainID.
