### PR TITLE
fix: deposit transactions not showing up

### DIFF
--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -21,7 +21,7 @@ export const incomingTxListSelector = (state) => {
     return []
   }
 
-  const network = state.metamask.network
+  const network = Number(state.metamask.network).toString()
   const selectedAddress = getSelectedAddress(state)
   return Object.values(state.metamask.incomingTransactions)
     .filter(({ metamaskNetworkId, txParams }) => (


### PR DESCRIPTION
Fix: <https://github.com/brave/brave-browser/issues/14566>

"incomingTxListSelector" returns the incoming transactions and is filtered by network === metamaskNetworkId.
network: is returning an int,
metamaskNetworkId: returns a string
Needed to convert network to a number and back to a string.

![Screen Shot 2021-03-17 at 11 47 40 AM](https://user-images.githubusercontent.com/40611140/111529810-34404180-8728-11eb-8caa-9ab0cec8e60c.png)
