### PR TITLE
Rename ENS to domain in search bar

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1167,7 +1167,7 @@
     "message": "Recipient Address"
   },
   "recipientAddressPlaceholder": {
-    "message": "Search, public address (0x), or ENS"
+    "message": "Search, public address (0x), or domain"
   },
   "rejectAll": {
     "message": "Reject All"

--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -162,7 +162,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
       await driver.delay(regularDelayMs)
 

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -189,7 +189,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -177,7 +177,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -218,7 +218,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))
@@ -282,7 +282,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))
@@ -321,7 +321,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))
@@ -843,7 +843,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -98,7 +98,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
 
-      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or ENS"]'))
+      const inputAddress = await driver.findElement(By.css('input[placeholder="Search, public address (0x), or domain"]'))
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))


### PR DESCRIPTION
"domain" is used as a generic term for both ENS and Unstoppable Domains.

Fixes brave/brave-browser#15797.