### PR TITLE
Updated End of Flow Message to Support Link

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -557,7 +557,7 @@
     "message": "If you need to back up your seed phrase again, you can find it in Settings -> Security."
   },
   "endOfFlowMessage7": {
-    "message": "If you ever have questions or see something fishy, email support@brave.com."
+    "message": "If you ever have questions or see something fishy, visit our wallet"
   },
   "endOfFlowMessage8": {
     "message": "Brave cannot recover your seedphrase."
@@ -567,6 +567,9 @@
   },
   "endOfFlowMessage10": {
     "message": "All Done"
+  },
+  "endOfFlowMessage11": {
+    "message": "support forum."
   },
   "externalExtension": {
     "message": "External Extension"

--- a/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
@@ -68,7 +68,16 @@ export default class EndOfFlowScreen extends PureComponent {
           { '• ' + t('endOfFlowMessage6') }
         </div>
         <div className="end-of-flow__text-3">
-          { '• ' + t('endOfFlowMessage7') }
+          { '• ' + t('endOfFlowMessage7') }&nbsp;
+          <a
+            href="https://community.brave.com/c/support-and-troubleshooting/wallet/131"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="first-time-flow__link-text-underlined">
+              {t('endOfFlowMessage11')}
+            </span>
+          </a>
         </div>
         <div className="first-time-flow__text-block end-of-flow__text-4">
           { '*' + t('endOfFlowMessage8') }&nbsp;

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -161,4 +161,9 @@
   &__link-text {
     color: $primary-blue;
   }
+
+  &__link-text-underlined {
+    color: $primary-blue;
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
Resolves <https://github.com/brave/brave-browser/issues/15519>

Changed the end of flow support message to link to https://community.brave.com/c/support-and-troubleshooting/wallet/131 instead of support@brave.com 

https://user-images.githubusercontent.com/40611140/118138073-27a43680-b3c3-11eb-9208-06f6c5fa3ffa.mov
