### PR TITLE
Notify browser of last wallet unlock activity

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1727,7 +1727,13 @@ export default class MetamaskController extends EventEmitter {
     const initState = opts.initState || {}
 
     this.keyringController.memStore.subscribe((s) => this._onKeyringControllerUpdate(s))
-    this.keyringController.on('unlock', () => this.emit('unlock'))
+    this.keyringController.on('unlock', () => {
+      if (chrome.braveWallet && chrome.braveWallet.notifyWalletUnlock) { // eslint-disable-line no-undef
+        chrome.braveWallet.notifyWalletUnlock() // eslint-disable-line no-undef
+      }
+      this.emit('unlock')
+    })
+
 
     this.permissionsController = new PermissionsController({
       getKeyringAccounts: this.keyringController.getAccounts.bind(this.keyringController),


### PR DESCRIPTION
Related PR:
https://github.com/brave/brave-core/pull/9205

Resolves brave/brave-browser#16174
