### PR TITLE
fix(swap): improve privacy policy text display

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1535,11 +1535,8 @@
   "swapPrivacyPolicy": {
     "message": "Swap Privacy Policy"
   },
-  "swapPrivacyPolicyDescriptionPart1": {
-    "message": "Brave uses "
-  },
-  "swapPrivacyPolicyDescriptionPart2": {
-    "message": " as a DEX aggregator. 0x will process the Ethereum address and IP address to fulfil a transaction (including getting quotes). 0x will ONLY use this data for the purposes of processing transactions."
+  "swapPrivacyPolicyDescription": {
+    "message": "Brave uses $1 as a DEX aggregator. 0x will process the Ethereum address and IP address to fulfil a transaction (including getting quotes). 0x will ONLY use this data for the purposes of processing transactions."
   },
   "symbol": {
     "message": "Symbol"

--- a/ui/app/pages/settings/security-tab/security-tab.component.js
+++ b/ui/app/pages/settings/security-tab/security-tab.component.js
@@ -139,17 +139,19 @@ export default class SecurityTab extends PureComponent {
 
   renderSwapSection () {
     const { t } = this.context
+
+    const msg = t('swapPrivacyPolicyDescription', [
+      `<a href="https://0x.org" style="color:#037dd6">0x</a>`,
+    ])
+
     return (
       <div className="settings-page__content-row">
         <div className="settings-page__content-item">
-          <span>{ t('swapPrivacyPolicy') }</span>
-          <div className="settings-page__content-description">
-            {t('swapPrivacyPolicyDescriptionPart1')}
-            <a href="https://0x.org" style={{ color: '#037dd6' }}>
-              0x
-            </a>
-            {t('swapPrivacyPolicyDescriptionPart2')}
-          </div>
+          <span>{t('swapPrivacyPolicy')}</span>
+          <div
+            className="settings-page__content-description"
+            dangerouslySetInnerHTML={{ __html: msg }}
+          />
         </div>
       </div>
     )


### PR DESCRIPTION
Resolves issue raised by @bbondy here: https://github.com/brave/ethereum-remote-client/pull/248#discussion_r662385944

> This can't be done for localization reasons. I'm not super worried since this is not long term but it's still not right and not ideal to split strings like that. Let's fix in a follow up.
