### PR TITLE
chore(swap): add affiliate address to track 0x swap activity

### DIFF
--- a/app/scripts/controllers/swap.js
+++ b/app/scripts/controllers/swap.js
@@ -14,7 +14,7 @@ export default class SwapsController {
   async quote (fromAsset, toAsset, amount, gasPrice, slippage, selectedAddress, network, full) {
     const config = getConfig(network)
 
-    const qs = createQueryString({
+    const baseQueryObj = {
       takerAddress: selectedAddress,
       sellAmount: amount,
       buyToken: toAsset.address || toAsset.symbol,
@@ -23,7 +23,17 @@ export default class SwapsController {
       slippagePercentage: slippage / 100,
       feeRecipient: config.feeRecipient,
       gasPrice,
-    })
+    }
+
+    // Add an affiliateAddress field if querying the full quote, which allows
+    // us to tag the trade for metrics and/or aggregated statistics.
+    //
+    // We're using the same ETH address as feeRecipient for this purpose.
+    const queryObj = full
+      ? { affiliateAddress: config.feeRecipient, ...baseQueryObj }
+      : baseQueryObj
+
+    const qs = createQueryString(queryObj)
 
     const path = full ? 'quote' : 'price'
     const quoteUrl = `${config.swapAPIURL}/${path}?${qs}`

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -70,7 +70,7 @@ describe('Swaps Controller', function () {
   let swapsController
 
   beforeEach(function () {
-    const qs = createQueryString({
+    const baseQueryObj = {
       takerAddress: '0xFOODBABE',
       sellAmount: '100',
       buyToken: '0xDEADBEEF',
@@ -79,14 +79,19 @@ describe('Swaps Controller', function () {
       slippagePercentage: '0.03',
       feeRecipient: '0xbd9420A98a7Bd6B89765e5715e169481602D9c3d',
       gasPrice: '21',
+    }
+    const qsPrice = createQueryString(baseQueryObj)
+    const qsQuote = createQueryString({
+      affiliateAddress: '0xbd9420A98a7Bd6B89765e5715e169481602D9c3d',
+      ...baseQueryObj,
     })
 
     nock('https://api.0x.org/swap/v1/quote')
-      .get(`?${qs}`)
+      .get(`?${qsQuote}`)
       .reply(200, quoteResponse)
 
     nock('https://api.0x.org/swap/v1/price')
-      .get(`?${qs}`)
+      .get(`?${qsPrice}`)
       .reply(200, priceResponse)
 
     swapsController = new SwapsController({})


### PR DESCRIPTION
Adding `affiliateAddress` as per an [internal conversation](https://bravesoftware.slack.com/archives/C01CBS688A1/p1625089413044400) on the Slack channel #0x-shared:

> This will allow us to track data (namely volume, users, traded pairs, etc) internally and thus enable us to give you some Metabase dashboards where you can see this data. If you add an `affiliateAddress` we can also get you added on 0xTracker.com along with our other integrators.