### PR TITLE
Fix swap bugs for Milestone 1.0.32

### DIFF
--- a/ui/app/components/ui/unit-input/unit-input.component.js
+++ b/ui/app/components/ui/unit-input/unit-input.component.js
@@ -58,8 +58,8 @@ export default class UnitInput extends PureComponent {
   getInputWidth (value) {
     const valueString = String(value)
     const valueLength = valueString.length || 1
-    const decimalPointDeficit = valueString.match(/\./) ? -0.5 : 0
-    return (valueLength + decimalPointDeficit + 0.5) + 'ch'
+    const decimalPointDeficit = valueString.match(/\./) ? -0.56 : 0
+    return (valueLength + decimalPointDeficit + 0.56) + 'ch'
   }
 
   render () {

--- a/ui/app/css/itcss/components/swap.scss
+++ b/ui/app/css/itcss/components/swap.scss
@@ -978,6 +978,11 @@
     height: 0;
   }
 
+  .btn-secondary[disabled] {
+    opacity: 0.75;
+    color: #b0d7f2 !important;
+  }
+
   &__gas-fee-display {
     width: 100%;
     position: relative;

--- a/ui/app/pages/swap/swap-footer/swap-footer.component.js
+++ b/ui/app/pages/swap/swap-footer/swap-footer.component.js
@@ -171,14 +171,16 @@ export default class SwapFooter extends Component {
     const { t } = this.context
 
     return (
-      <PageContainerFooter
-        onSubmit={(e) => this.onSubmit(e)}
-        submitText={t('reviewSwap')}
-        disabled={this.reviewSwapButtonShouldBeDisabled()}
-        hideCancel
-      >
-        {this.renderFooterExtra()}
-      </PageContainerFooter>
+      <div className="swap-v2">
+        <PageContainerFooter
+          onSubmit={(e) => this.onSubmit(e)}
+          submitText={t('reviewSwap')}
+          disabled={this.reviewSwapButtonShouldBeDisabled()}
+          hideCancel
+        >
+          {this.renderFooterExtra()}
+        </PageContainerFooter>
+      </div>
     )
   }
 }

--- a/ui/app/pages/swap/swap.config.js
+++ b/ui/app/pages/swap/swap.config.js
@@ -10,7 +10,7 @@ export default function getConfig (network) {
     case ROPSTEN:
       return {
         swapAPIURL: 'https://ropsten.api.0x.org/swap/v1',
-        buyTokenPercentageFee: 0.00875,
+        buyTokenPercentageFee: '0.00875',
         feeRecipient: '0x7B4933b164092b480A7c1b9bbCdBc8Ecd5201B96',
       }
 
@@ -18,7 +18,7 @@ export default function getConfig (network) {
     default:
       return {
         swapAPIURL: 'https://api.0x.org/swap/v1',
-        buyTokenPercentageFee: 0.00875,
+        buyTokenPercentageFee: '0.00875',
         feeRecipient: '0xbd9420A98a7Bd6B89765e5715e169481602D9c3d',
       }
   }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -220,13 +220,20 @@ export function fetchSwapQuote (fromAsset, toAsset, amount, gasPrice, slippage, 
     const network = getNetworkIdentifier(state)
     const selectedAddress = getSelectedAddress(state)
 
-    const gasPriceDecimal = gasPrice && parseInt(gasPrice, 16).toString()
+    const gasPriceDecimal = gasPrice && ethers.BigNumber.from(
+      ethUtil.addHexPrefix(gasPrice),
+    ).toString()
+
+    const amountDecimal = ethers.BigNumber.from(
+      ethUtil.addHexPrefix(amount),
+    ).toString()
 
     const conn = exports.getBackgroundConnection()
+
     const quote = await conn.quote(
       fromAsset,
       toAsset,
-      parseInt(amount, 16),
+      amountDecimal,
       gasPriceDecimal,
       slippage,
       selectedAddress,


### PR DESCRIPTION
### Description

This PR fixes the following issues:
* https://github.com/brave/brave-browser/issues/16760
* https://github.com/brave/brave-browser/issues/16750
* https://github.com/brave/brave-browser/issues/16983

### Recording

https://user-images.githubusercontent.com/3684187/125864452-e7be88f8-e6ac-431c-b586-50ff28be9101.mov

### QA Test plan

* https://github.com/brave/brave-browser/issues/16760
  - Enter an integer value of 1000 or greater, and the quote should be correctly fetched.
  - Enter a floating-point value of 1000.0 or greater, and the quote should be correctly fetched.
  - Values less than 1000 (integers and floats) should continue to work as normal.
  - Verify if a manual change in gas price in the swap screen is taken into account.
  - Verify if the amount on Etherscan (after swap) is accurate.
  - Verify if the Brave fee of 0.875% is correctly subtracted.
* https://github.com/brave/brave-browser/issues/16750
  - Verify if the color and opacity changes in both light and dark mode.
* https://github.com/brave/brave-browser/issues/16983
  - Enter an integer amount, then click on the rightmost end of the number; verify if the cursor is displayed.
  - Enter a floating-point amount, then click on the rightmost end of the number; verify if the cursor is displayed.
  - Repeat the tests in the currency input of the Send screen as well.