### PR TITLE
chore(eip1559): upgrade ethereumjs-util to v7.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ before_install:
 branches:
   only:
     - master
+    - eip1559
 script:
   - yarn test:brave

--- a/app/scripts/account-import-strategies/index.js
+++ b/app/scripts/account-import-strategies/index.js
@@ -1,7 +1,7 @@
 import log from 'loglevel'
 import Wallet from 'ethereumjs-wallet'
 import importers from 'ethereumjs-wallet/thirdparty'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix, bufferToHex, isValidPrivate, stripHexPrefix, toBuffer } from 'ethereumjs-util'
 
 const accountImporter = {
 
@@ -21,14 +21,14 @@ const accountImporter = {
         throw new Error('Cannot import an empty key.')
       }
 
-      const prefixed = ethUtil.addHexPrefix(privateKey)
-      const buffer = ethUtil.toBuffer(prefixed)
+      const prefixed = addHexPrefix(privateKey)
+      const buffer = toBuffer(prefixed)
 
-      if (!ethUtil.isValidPrivate(buffer)) {
+      if (!isValidPrivate(buffer)) {
         throw new Error('Cannot import invalid private key.')
       }
 
-      const stripped = ethUtil.stripHexPrefix(prefixed)
+      const stripped = stripHexPrefix(prefixed)
       return stripped
     },
     'JSON File': (input, password) => {
@@ -48,7 +48,7 @@ const accountImporter = {
 
 function walletToPrivateKey (wallet) {
   const privateKeyBuffer = wallet.getPrivateKey()
-  return ethUtil.bufferToHex(privateKeyBuffer)
+  return bufferToHex(privateKeyBuffer)
 }
 
 export default accountImporter

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -1,4 +1,4 @@
-import ethUtil from 'ethereumjs-util'
+import { toChecksumAddress } from 'ethereumjs-util'
 import ObservableStore from 'obs-store'
 import punycode from 'punycode'
 import log from 'loglevel'
@@ -39,7 +39,7 @@ export default class EnsController {
   }
 
   reverseResolveAddress (address) {
-    return this._reverseResolveAddress(ethUtil.toChecksumAddress(address))
+    return this._reverseResolveAddress(toChecksumAddress(address))
   }
 
   async _reverseResolveAddress (address) {
@@ -72,7 +72,7 @@ export default class EnsController {
       return undefined
     }
 
-    if (ethUtil.toChecksumAddress(registeredAddress) !== address) {
+    if (toChecksumAddress(registeredAddress) !== address) {
       return undefined
     }
 

--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -1,7 +1,7 @@
 import ObservableStore from 'obs-store'
 import log from 'loglevel'
 import { normalize as normalizeAddress } from 'eth-sig-util'
-import ethUtil from 'ethereumjs-util'
+import { toChecksumAddress } from 'ethereumjs-util'
 
 /* eslint-disable accessor-pairs */
 
@@ -37,7 +37,7 @@ export default class TokenRatesController {
         const response = await window.fetch(`https://api.coingecko.com/api/v3/simple/token_price/ethereum?${query}`)
         const prices = await response.json()
         this._tokens.forEach((token) => {
-          const price = prices[token.address.toLowerCase()] || prices[ethUtil.toChecksumAddress(token.address)]
+          const price = prices[token.address.toLowerCase()] || prices[toChecksumAddress(token.address)]
           contractExchangeRates[normalizeAddress(token.address)] = price ? price[nativeCurrency] : 0
         })
       } catch (error) {

--- a/app/scripts/lib/decrypt-message-manager.js
+++ b/app/scripts/lib/decrypt-message-manager.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events'
 import ObservableStore from 'obs-store'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix, bufferToHex, stripHexPrefix } from 'ethereumjs-util'
 import { ethErrors } from 'eth-json-rpc-errors'
 import createId from './random-id'
 import { MESSAGE_TYPE } from './enums'
@@ -298,15 +298,15 @@ export default class DecryptMessageManager extends EventEmitter {
    */
   normalizeMsgData (data) {
     try {
-      const stripped = ethUtil.stripHexPrefix(data)
+      const stripped = stripHexPrefix(data)
       if (stripped.match(hexRe)) {
-        return ethUtil.addHexPrefix(stripped)
+        return addHexPrefix(stripped)
       }
     } catch (e) {
       log.debug(`Message was not hex encoded, interpreting as utf8.`)
     }
 
-    return ethUtil.bufferToHex(Buffer.from(data, 'utf8'))
+    return bufferToHex(Buffer.from(data, 'utf8'))
   }
 
 }

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events'
 import ObservableStore from 'obs-store'
-import ethUtil from 'ethereumjs-util'
+import { bufferToHex } from 'ethereumjs-util'
 import { ethErrors } from 'eth-json-rpc-errors'
 import createId from './random-id'
 import { MESSAGE_TYPE } from './enums'
@@ -280,6 +280,6 @@ function normalizeMsgData (data) {
     return data
   } else {
     // data is unicode, convert to hex
-    return ethUtil.bufferToHex(Buffer.from(data, 'utf8'))
+    return bufferToHex(Buffer.from(data, 'utf8'))
   }
 }

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events'
 import ObservableStore from 'obs-store'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix, bufferToHex, stripHexPrefix } from 'ethereumjs-util'
 import { ethErrors } from 'eth-json-rpc-errors'
 import createId from './random-id'
 import { MESSAGE_TYPE } from './enums'
@@ -286,15 +286,15 @@ export default class PersonalMessageManager extends EventEmitter {
    */
   normalizeMsgData (data) {
     try {
-      const stripped = ethUtil.stripHexPrefix(data)
+      const stripped = stripHexPrefix(data)
       if (stripped.match(hexRe)) {
-        return ethUtil.addHexPrefix(stripped)
+        return addHexPrefix(stripped)
       }
     } catch (e) {
       log.debug(`Message was not hex encoded, interpreting as utf8.`)
     }
 
-    return ethUtil.bufferToHex(Buffer.from(data, 'utf8'))
+    return bufferToHex(Buffer.from(data, 'utf8'))
   }
 
 }

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -1,5 +1,5 @@
 import extension from 'extensionizer'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix, stripHexPrefix } from 'ethereumjs-util'
 import assert from 'assert'
 import BN from 'bn.js'
 import { memoize } from 'lodash'
@@ -103,7 +103,7 @@ function sufficientBalance (txParams, hexBalance) {
  *
  */
 function bnToHex (inputBn) {
-  return ethUtil.addHexPrefix(inputBn.toString(16))
+  return addHexPrefix(inputBn.toString(16))
 }
 
 /**
@@ -114,7 +114,7 @@ function bnToHex (inputBn) {
  *
  */
 function hexToBn (inputHex) {
-  return new BN(ethUtil.stripHexPrefix(inputHex), 16)
+  return new BN(stripHexPrefix(inputHex), 16)
 }
 
 /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -10,6 +10,7 @@ import pump from 'pump'
 import Dnode from 'dnode'
 import extension from 'extensionizer'
 import ObservableStore from 'obs-store'
+import { toChecksumAddress, stripHexPrefix } from 'ethereumjs-util'
 import ComposableObservableStore from './lib/ComposableObservableStore'
 import asStream from 'obs-store/lib/asStream'
 import AccountTracker from './lib/account-tracker'
@@ -50,7 +51,6 @@ import accountImporter from './account-import-strategies'
 import getBuyEthUrl from './lib/buy-eth-url'
 import { Mutex } from 'await-semaphore'
 import { version } from '../manifest/_base.json'
-import ethUtil from 'ethereumjs-util'
 
 import seedPhraseVerifier from './lib/seed-phrase-verifier'
 import log from 'loglevel'
@@ -608,13 +608,13 @@ export default class MetamaskController extends EventEmitter {
     // Filter ERC20 tokens
     const filteredAccountTokens = {}
     Object.keys(accountTokens).forEach((address) => {
-      const checksummedAddress = ethUtil.toChecksumAddress(address)
+      const checksummedAddress = toChecksumAddress(address)
       filteredAccountTokens[checksummedAddress] = {}
       Object.keys(accountTokens[address]).forEach(
         (networkType) => (filteredAccountTokens[checksummedAddress][networkType] = networkType !== 'mainnet' ?
           accountTokens[address][networkType] :
           accountTokens[address][networkType].filter(({ address }) => {
-            const tokenAddress = ethUtil.toChecksumAddress(address)
+            const tokenAddress = toChecksumAddress(address)
             return contractMap[tokenAddress] ? contractMap[tokenAddress].erc20 : true
           })
         ),
@@ -639,8 +639,8 @@ export default class MetamaskController extends EventEmitter {
     )
     const simpleKeyPairAccounts = simpleKeyPairKeyringAccounts.reduce((acc, accounts) => [...acc, ...accounts], [])
     const accounts = {
-      hd: hdAccounts.filter((item, pos) => (hdAccounts.indexOf(item) === pos)).map((address) => ethUtil.toChecksumAddress(address)),
-      simpleKeyPair: simpleKeyPairAccounts.filter((item, pos) => (simpleKeyPairAccounts.indexOf(item) === pos)).map((address) => ethUtil.toChecksumAddress(address)),
+      hd: hdAccounts.filter((item, pos) => (hdAccounts.indexOf(item) === pos)).map((address) => toChecksumAddress(address)),
+      simpleKeyPair: simpleKeyPairAccounts.filter((item, pos) => (simpleKeyPairAccounts.indexOf(item) === pos)).map((address) => toChecksumAddress(address)),
       ledger: [],
       trezor: [],
     }
@@ -650,7 +650,7 @@ export default class MetamaskController extends EventEmitter {
     let transactions = this.txController.store.getState().transactions
     // delete tx for other accounts that we're not importing
     transactions = transactions.filter((tx) => {
-      const checksummedTxFrom = ethUtil.toChecksumAddress(tx.txParams.from)
+      const checksummedTxFrom = toChecksumAddress(tx.txParams.from)
       return (
         accounts.hd.includes(checksummedTxFrom)
       )
@@ -1097,7 +1097,7 @@ export default class MetamaskController extends EventEmitter {
     const msgId = msgParams.metamaskId
     const msg = this.decryptMessageManager.getMsg(msgId)
     try {
-      const stripped = ethUtil.stripHexPrefix(msgParams.data)
+      const stripped = stripHexPrefix(msgParams.data)
       const buff = Buffer.from(stripped, 'hex')
       msgParams.data = JSON.parse(buff.toString('utf8'))
 
@@ -1125,7 +1125,7 @@ export default class MetamaskController extends EventEmitter {
     try {
       const cleanMsgParams = await this.decryptMessageManager.approveMessage(msgParams)
 
-      const stripped = ethUtil.stripHexPrefix(cleanMsgParams.data)
+      const stripped = stripHexPrefix(cleanMsgParams.data)
       const buff = Buffer.from(stripped, 'hex')
       cleanMsgParams.data = JSON.parse(buff.toString('utf8'))
 

--- a/app/scripts/migrations/025.js
+++ b/app/scripts/migrations/025.js
@@ -6,7 +6,7 @@ const version = 25
 normalizes txParams on unconfirmed txs
 
 */
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 
 import { cloneDeep } from 'lodash'
 
@@ -45,13 +45,13 @@ function transformState (state) {
 function normalizeTxParams (txParams) {
   // functions that handle normalizing of that key in txParams
   const whiteList = {
-    from: (from) => ethUtil.addHexPrefix(from).toLowerCase(),
-    to: () => ethUtil.addHexPrefix(txParams.to).toLowerCase(),
-    nonce: (nonce) => ethUtil.addHexPrefix(nonce),
-    value: (value) => ethUtil.addHexPrefix(value),
-    data: (data) => ethUtil.addHexPrefix(data),
-    gas: (gas) => ethUtil.addHexPrefix(gas),
-    gasPrice: (gasPrice) => ethUtil.addHexPrefix(gasPrice),
+    from: (from) => addHexPrefix(from).toLowerCase(),
+    to: () => addHexPrefix(txParams.to).toLowerCase(),
+    nonce: (nonce) => addHexPrefix(nonce),
+    value: (value) => addHexPrefix(value),
+    data: (data) => addHexPrefix(data),
+    gas: (gas) => addHexPrefix(gas),
+    gasPrice: (gasPrice) => addHexPrefix(gasPrice),
   }
 
   // apply only keys in the whiteList

--- a/app/scripts/migrations/039.js
+++ b/app/scripts/migrations/039.js
@@ -1,6 +1,6 @@
 const version = 39
 import { cloneDeep } from 'lodash'
-import ethUtil from 'ethereumjs-util'
+import { toChecksumAddress } from 'ethereumjs-util'
 
 const DAI_V1_CONTRACT_ADDRESS = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
 const DAI_V1_TOKEN_SYMBOL = 'DAI'
@@ -9,7 +9,7 @@ const SAI_TOKEN_SYMBOL = 'SAI'
 function isOldDai (token = {}) {
   return token && typeof token === 'object' &&
     token.symbol === DAI_V1_TOKEN_SYMBOL &&
-    ethUtil.toChecksumAddress(token.address) === DAI_V1_CONTRACT_ADDRESS
+    toChecksumAddress(token.address) === DAI_V1_CONTRACT_ADDRESS
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "ethereum-ens-network-map": "^1.0.2",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-tx": "1.3.7",
-    "ethereumjs-util": "5.1.0",
+    "ethereumjs-util": "^7.1.0",
     "ethereumjs-wallet": "^0.6.0",
     "ethers": "^5.0.31",
     "ethjs": "^0.4.0",

--- a/test/unit/app/account-import-strategies.spec.js
+++ b/test/unit/app/account-import-strategies.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import ethUtil from 'ethereumjs-util'
+import { stripHexPrefix } from 'ethereumjs-util'
 import accountImporter from '../../../app/scripts/account-import-strategies/index'
 
 describe('Account Import Strategies', function () {
@@ -9,7 +9,7 @@ describe('Account Import Strategies', function () {
   describe('private key import', function () {
     it('imports a private key and strips 0x prefix', async function () {
       const importPrivKey = await accountImporter.importAccount('Private Key', [ privkey ])
-      assert.equal(importPrivKey, ethUtil.stripHexPrefix(privkey))
+      assert.equal(importPrivKey, stripHexPrefix(privkey))
     })
 
     it('throws an error for empty string private key', async function () {

--- a/test/unit/app/controllers/ens-controller-test.js
+++ b/test/unit/app/controllers/ens-controller-test.js
@@ -81,7 +81,7 @@ describe('EnsController', function () {
       const ens = new EnsController({
         ens: {
           reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
-          lookup: sinon.stub().withArgs('peaksignal.eth').returns('0xfoo'),
+          lookup: sinon.stub().withArgs('peaksignal.eth').returns('0xdeadbeef'),
         },
         networkStore,
       })

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -2,7 +2,7 @@ import assert from 'assert'
 import sinon from 'sinon'
 import { cloneDeep } from 'lodash'
 import nock from 'nock'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix, bufferToHex, pubToAddress } from 'ethereumjs-util'
 import { obj as createThoughStream } from 'through2'
 import firstTimeState from '../../localhostState'
 import createTxMeta from '../../../lib/createTxMeta'
@@ -155,10 +155,10 @@ describe('MetaMaskController', function () {
         const simpleKeyrings = metamaskController.keyringController.getKeyringsByType('Simple Key Pair')
         const privKeyBuffer = simpleKeyrings[0].wallets[0]._privKey
         const pubKeyBuffer = simpleKeyrings[0].wallets[0]._pubKey
-        const addressBuffer = ethUtil.pubToAddress(pubKeyBuffer)
-        const privKey = ethUtil.bufferToHex(privKeyBuffer)
-        const pubKey = ethUtil.bufferToHex(addressBuffer)
-        assert.equal(privKey, ethUtil.addHexPrefix(importPrivkey))
+        const addressBuffer = pubToAddress(pubKeyBuffer)
+        const privKey = bufferToHex(privKeyBuffer)
+        const pubKey = bufferToHex(addressBuffer)
+        assert.equal(privKey, addHexPrefix(importPrivkey))
         assert.equal(pubKey, '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc')
       })
 

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert'
 import EventEmitter from 'events'
-import ethUtil from 'ethereumjs-util'
+import { toBuffer } from 'ethereumjs-util'
 import EthTx from 'ethereumjs-tx'
 import ObservableStore from 'obs-store'
 import sinon from 'sinon'
@@ -306,7 +306,7 @@ describe('Transaction Controller', function () {
     it('prepares a tx with the chainId set', async function () {
       txController.addTx({ id: '1', status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }, noop)
       const rawTx = await txController.signTransaction('1')
-      const ethTx = new EthTx(ethUtil.toBuffer(rawTx))
+      const ethTx = new EthTx(toBuffer(rawTx))
       assert.equal(ethTx.getChainId(), parseInt(currentNetworkId))
     })
   })

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1136,7 +1136,7 @@ describe('Actions', function () {
       const addToAddressBookSpy = sinon.stub(background, 'setAddressBook')
         .callsArgWith(4, null, true)
       const store = mockStore()
-      await store.dispatch(actions.addToAddressBook('test'))
+      await store.dispatch(actions.addToAddressBook('0xdeadbeef'))
       assert(addToAddressBookSpy.calledOnce)
       addToAddressBookSpy.restore()
     })

--- a/ui/app/components/app/account-menu/tests/account-menu.test.js
+++ b/ui/app/components/app/account-menu/tests/account-menu.test.js
@@ -28,12 +28,12 @@ describe('Account Menu', function () {
     addressConnectedDomainMap: {},
     accounts: [
       {
-        address: '0xAddress',
+        address: '0xcafebabe',
         name: 'Account 1',
         balance: '0x0',
       },
       {
-        address: '0xImportedAddress',
+        address: '0xdeadbeef',
         name: 'Imported Account 1',
         balance: '0x0',
       },
@@ -42,13 +42,13 @@ describe('Account Menu', function () {
       {
         type: 'HD Key Tree',
         accounts: [
-          '0xAdress',
+          '0xcafebabe',
         ],
       },
       {
         type: 'Simple Key Pair',
         accounts: [
-          '0xImportedAddress',
+          '0xdeadbeef',
         ],
       },
     ],
@@ -92,7 +92,7 @@ describe('Account Menu', function () {
       click.first().simulate('click')
 
       assert(props.showAccountDetail.calledOnce)
-      assert.equal(props.showAccountDetail.getCall(0).args[0], '0xAddress')
+      assert.equal(props.showAccountDetail.getCall(0).args[0], '0xcafebabe')
     })
 
     it('render imported account label', function () {

--- a/ui/app/components/app/modals/cancel-transaction/cancel-transaction.container.js
+++ b/ui/app/components/app/modals/cancel-transaction/cancel-transaction.container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import { compose } from 'redux'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import { multiplyCurrencies } from '../../../../helpers/utils/conversion-util'
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props'
 import CancelTransaction from './cancel-transaction.component'
@@ -14,7 +14,7 @@ const mapStateToProps = (state, ownProps) => {
   const transaction = currentNetworkTxList.find(({ id }) => id === transactionId)
   const transactionStatus = transaction ? transaction.status : ''
 
-  const defaultNewGasPrice = ethUtil.addHexPrefix(
+  const defaultNewGasPrice = addHexPrefix(
     multiplyCurrencies(originalGasPrice, 1.1, {
       toNumericBase: 'hex',
       multiplicandBase: 16,

--- a/ui/app/components/app/modals/confirm-remove-account/tests/confirm-remove-account.test.js
+++ b/ui/app/components/app/modals/confirm-remove-account/tests/confirm-remove-account.test.js
@@ -21,7 +21,7 @@ describe('Confirm Remove Account', function () {
     removeAccount: sinon.stub().resolves(),
     network: '101',
     identity: {
-      address: '0xAddress',
+      address: '0xcafebabe',
       name: 'Account 1',
     },
   }

--- a/ui/app/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/app/components/app/signature-request-original/signature-request-original.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ethUtil from 'ethereumjs-util'
+import { stripHexPrefix } from 'ethereumjs-util'
 import classnames from 'classnames'
 import { ObjectInspector } from 'react-inspector'
 
@@ -161,7 +161,7 @@ export default class SignatureRequestOriginal extends Component {
 
   msgHexToText = (hex) => {
     try {
-      const stripped = ethUtil.stripHexPrefix(hex)
+      const stripped = stripHexPrefix(hex)
       const buff = Buffer.from(stripped, 'hex')
       return buff.length === 32 ? hex : buff.toString('utf8')
     } catch (e) {

--- a/ui/app/components/ui/identicon/tests/identicon.component.test.js
+++ b/ui/app/components/ui/identicon/tests/identicon.component.test.js
@@ -42,7 +42,7 @@ describe('Identicon', function () {
       <Identicon
         store={store}
         className="test-address"
-        address="0xTest"
+        address="0xdeadbeef"
       />,
     )
 

--- a/ui/app/components/ui/token-input/token-input.component.js
+++ b/ui/app/components/ui/token-input/token-input.component.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
+import { addHexPrefix } from 'ethereumjs-util'
 import UnitInput from '../unit-input'
 import CurrencyDisplay from '../currency-display'
 import { getWeiHexFromDecimalValue } from '../../../helpers/utils/conversions.util'
-import ethUtil from 'ethereumjs-util'
 import { conversionUtil, multiplyCurrencies } from '../../../helpers/utils/conversion-util'
 import { ETH } from '../../../helpers/constants/common'
 
@@ -59,7 +59,7 @@ export default class TokenInput extends PureComponent {
     const { value: hexValue, token: { decimals, symbol } = {} } = props
 
     const multiplier = Math.pow(10, Number(decimals || 0))
-    const decimalValueString = conversionUtil(ethUtil.addHexPrefix(hexValue), {
+    const decimalValueString = conversionUtil(addHexPrefix(hexValue), {
       fromNumericBase: 'hex',
       toNumericBase: 'dec',
       toCurrency: symbol,

--- a/ui/app/helpers/utils/confirm-tx.util.js
+++ b/ui/app/helpers/utils/confirm-tx.util.js
@@ -1,6 +1,6 @@
 import currencyFormatter from 'currency-formatter'
 import currencies from 'currency-formatter/currencies'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import BigNumber from 'bignumber.js'
 
 import {
@@ -13,7 +13,7 @@ import {
 import { unconfirmedTransactionsCountSelector } from '../../selectors'
 
 export function increaseLastGasPrice (lastGasPrice) {
-  return ethUtil.addHexPrefix(multiplyCurrencies(lastGasPrice || '0x0', 1.1, {
+  return addHexPrefix(multiplyCurrencies(lastGasPrice || '0x0', 1.1, {
     multiplicandBase: 16,
     multiplierBase: 10,
     toNumericBase: 'hex',
@@ -28,7 +28,7 @@ export function hexGreaterThan (a, b) {
 }
 
 export function getHexGasTotal ({ gasLimit, gasPrice }) {
-  return ethUtil.addHexPrefix(multiplyCurrencies(gasLimit || '0x0', gasPrice || '0x0', {
+  return addHexPrefix(multiplyCurrencies(gasLimit || '0x0', gasPrice || '0x0', {
     toNumericBase: 'hex',
     multiplicandBase: 16,
     multiplierBase: 16,

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -23,9 +23,7 @@
 
 import BigNumber from 'bignumber.js'
 
-import ethUtil, { stripHexPrefix } from 'ethereumjs-util'
-
-const BN = ethUtil.BN
+import { BN, stripHexPrefix } from 'ethereumjs-util'
 
 // Big Number Constants
 const BIG_NUMBER_WEI_MULTIPLIER = new BigNumber('1000000000000000000')

--- a/ui/app/helpers/utils/conversions.util.js
+++ b/ui/app/helpers/utils/conversions.util.js
@@ -1,9 +1,9 @@
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import { ETH, GWEI, WEI } from '../constants/common'
 import { conversionUtil, addCurrencies, subtractCurrencies } from './conversion-util'
 
 export function bnToHex (inputBn) {
-  return ethUtil.addHexPrefix(inputBn.toString(16))
+  return addHexPrefix(inputBn.toString(16))
 }
 
 export function hexToDecimal (hexValue) {

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -1,6 +1,6 @@
 /* eslint camelcase: 0 */
 
-import ethUtil from 'ethereumjs-util'
+import { bufferToHex, keccak } from 'ethereumjs-util'
 
 const inDevelopment = process.env.METAMASK_DEBUG || process.env.IN_TEST
 
@@ -169,7 +169,7 @@ function composeUrl (config) {
   const url = currentPath ? `&url=${encodeURIComponent(`${METAMETRICS_TRACKING_URL}${currentPath}`)}` : ''
   const _id = metaMetricsId && !excludeMetaMetricsId ? `&_id=${metaMetricsId.slice(2, 18)}` : ''
   const rand = `&rand=${String(Math.random()).slice(2)}`
-  const pv_id = currentPath ? `&pv_id=${ethUtil.bufferToHex(ethUtil.sha3(currentPath)).slice(2, 8)}` : ''
+  const pv_id = currentPath ? `&pv_id=${bufferToHex(keccak(currentPath)).slice(2, 8)}` : ''
   const uid = metaMetricsId && !excludeMetaMetricsId
     ? `&uid=${metaMetricsId.slice(2, 18)}`
     : excludeMetaMetricsId

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -1,4 +1,4 @@
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import MethodRegistry from 'eth-method-registry'
 import abi from 'human-standard-token-abi'
 import abiDecoder from 'abi-decoder'
@@ -102,7 +102,7 @@ export function isConfirmDeployContract (txData = {}) {
  * @returns {string} - The four-byte method signature
  */
 export function getFourBytePrefix (data = '') {
-  const prefixedData = ethUtil.addHexPrefix(data)
+  const prefixedData = addHexPrefix(data)
   const fourBytePrefix = prefixedData.slice(0, 10)
   return fourBytePrefix
 }
@@ -204,7 +204,7 @@ export function sumHexes (...args) {
     })
   })
 
-  return ethUtil.addHexPrefix(total)
+  return addHexPrefix(total)
 }
 
 /**

--- a/ui/app/helpers/utils/util.test.js
+++ b/ui/app/helpers/utils/util.test.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import ethUtil from 'ethereumjs-util'
+import { BN, toChecksumAddress } from 'ethereumjs-util'
 import * as util from './util'
 
 describe('util', function () {
@@ -88,7 +88,7 @@ describe('util', function () {
     it('should recognize this sample hashed address', function () {
       const address = '0x5Fda30Bb72B8Dfe20e48A00dFc108d0915BE9Bb0'
       const result = util.isValidAddress(address)
-      const hashed = ethUtil.toChecksumAddress(address.toLowerCase())
+      const hashed = toChecksumAddress(address.toLowerCase())
       assert.equal(hashed, address, 'example is hashed correctly')
       assert.ok(result, 'is valid by our check')
     })
@@ -176,13 +176,13 @@ describe('util', function () {
     })
 
     it('should return 1.0000 ETH', function () {
-      const input = new ethUtil.BN(ethInWei, 10).toJSON()
+      const input = new BN(ethInWei, 10).toJSON()
       const result = util.formatBalance(input, 4)
       assert.equal(result, '1.0000 ETH')
     })
 
     it('should return 0.500 ETH', function () {
-      const input = new ethUtil.BN(ethInWei, 10).div(new ethUtil.BN('2', 10)).toJSON()
+      const input = new BN(ethInWei, 10).div(new BN('2', 10)).toJSON()
       const result = util.formatBalance(input, 3)
       assert.equal(result, '0.500 ETH')
     })
@@ -211,77 +211,6 @@ describe('util', function () {
   })
 
   describe('normalizing values', function () {
-    describe('#normalizeToWei', function () {
-      it('should convert an eth to the appropriate equivalent values', function () {
-        const valueTable = {
-          wei: '1000000000000000000',
-          kwei: '1000000000000000',
-          mwei: '1000000000000',
-          gwei: '1000000000',
-          szabo: '1000000',
-          finney: '1000',
-          ether: '1',
-          // kether:'0.001',
-          // mether:'0.000001',
-          // AUDIT: We're getting BN numbers on these ones.
-          // I think they're big enough to ignore for now.
-          // gether:'0.000000001',
-          // tether:'0.000000000001',
-        }
-        const oneEthBn = new ethUtil.BN(ethInWei, 10)
-
-        Object.keys(valueTable).forEach((currency) => {
-          const value = new ethUtil.BN(valueTable[currency], 10)
-          const output = util.normalizeToWei(value, currency)
-          assert.equal(output.toString(10), valueTable.wei, `value of ${output.toString(10)} ${currency} should convert to ${oneEthBn}`)
-        })
-      })
-    })
-
-    describe('#normalizeEthStringToWei', function () {
-      it('should convert decimal eth to pure wei BN', function () {
-        const input = '1.23456789'
-        const output = util.normalizeEthStringToWei(input)
-        assert.equal(output.toString(10), '1234567890000000000')
-      })
-
-      it('should convert 1 to expected wei', function () {
-        const input = '1'
-        const output = util.normalizeEthStringToWei(input)
-        assert.equal(output.toString(10), ethInWei)
-      })
-
-      it('should account for overflow numbers gracefully by dropping extra precision.', function () {
-        const input = '1.11111111111111111111'
-        const output = util.normalizeEthStringToWei(input)
-        assert.equal(output.toString(10), '1111111111111111111')
-      })
-
-      it('should not truncate very exact wei values that do not have extra precision.', function () {
-        const input = '1.100000000000000001'
-        const output = util.normalizeEthStringToWei(input)
-        assert.equal(output.toString(10), '1100000000000000001')
-      })
-    })
-
-    describe('#normalizeNumberToWei', function () {
-      it('should handle a simple use case', function () {
-        const input = 0.0002
-        const output = util.normalizeNumberToWei(input, 'ether')
-        const str = output.toString(10)
-        assert.equal(str, '200000000000000')
-      })
-
-      it('should convert a kwei number to the appropriate equivalent wei', function () {
-        const result = util.normalizeNumberToWei(1.111, 'kwei')
-        assert.equal(result.toString(10), '1111', 'accepts decimals')
-      })
-
-      it('should convert a ether number to the appropriate equivalent wei', function () {
-        const result = util.normalizeNumberToWei(1.111, 'ether')
-        assert.equal(result.toString(10), '1111000000000000000', 'accepts decimals')
-      })
-    })
     describe('#isHex', function () {
       it('should return true when given a hex string', function () {
         const result = util.isHex('c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')

--- a/ui/app/pages/add-token/add-token.component.js
+++ b/ui/app/pages/add-token/add-token.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix, isValidAddress as isValidAddressFunc } from 'ethereumjs-util'
 import { checkExistingAddresses } from '../../helpers/utils/util'
 import { tokenInfoGetter } from '../../helpers/utils/token-util'
 import { CONFIRM_ADD_TOKEN_ROUTE } from '../../helpers/constants/routes'
@@ -150,8 +150,8 @@ class AddToken extends Component {
       autoFilled: false,
     })
 
-    const isValidAddress = ethUtil.isValidAddress(customAddress)
-    const standardAddress = ethUtil.addHexPrefix(customAddress).toLowerCase()
+    const isValidAddress = isValidAddressFunc(customAddress)
+    const standardAddress = addHexPrefix(customAddress).toLowerCase()
 
     switch (true) {
       case !isValidAddress:

--- a/ui/app/pages/confirm-deploy-contract/confirm-deploy-contract.component.js
+++ b/ui/app/pages/confirm-deploy-contract/confirm-deploy-contract.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ethUtil from 'ethereumjs-util'
+import { toBuffer } from 'ethereumjs-util'
 import ConfirmTransactionBase from '../confirm-transaction-base'
 
 export default class ConfirmDeployContract extends Component {
@@ -39,7 +39,7 @@ export default class ConfirmDeployContract extends Component {
               { `${t('bytes')}:` }
             </div>
             <div>
-              { ethUtil.toBuffer(data).length }
+              { toBuffer(data).length }
             </div>
           </div>
         </div>

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -1,6 +1,6 @@
-import ethUtil from 'ethereumjs-util'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { toBuffer } from 'ethereumjs-util'
 import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../../app/scripts/lib/enums'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
 import ConfirmPageContainer, { ConfirmDetailRow } from '../../components/app/confirm-page-container'
@@ -357,7 +357,7 @@ export default class ConfirmTransactionBase extends Component {
           )
         }
         <div className="confirm-page-container-content__data-box-label">
-          {`${t('hexData')}: ${ethUtil.toBuffer(data).length} bytes`}
+          {`${t('hexData')}: ${toBuffer(data).length} bytes`}
         </div>
         <div className="confirm-page-container-content__data-box">
           { data }

--- a/ui/app/pages/send/send-content/add-recipient/add-recipient.js
+++ b/ui/app/pages/send/send-content/add-recipient/add-recipient.js
@@ -1,12 +1,12 @@
+import { toChecksumAddress } from 'ethereumjs-util'
+
 import {
   REQUIRED_ERROR,
   INVALID_RECIPIENT_ADDRESS_ERROR,
   KNOWN_RECIPIENT_ADDRESS_ERROR,
   INVALID_RECIPIENT_ADDRESS_NOT_ETH_NETWORK_ERROR,
 } from '../../send.constants'
-
 import { isValidAddress, isEthNetwork, checkExistingAddresses } from '../../../../helpers/utils/util'
-import ethUtil from 'ethereumjs-util'
 import contractMap from '@metamask/contract-metadata'
 
 export function getToErrorObject (to, hasHexData = false, network) {
@@ -24,7 +24,7 @@ export function getToErrorObject (to, hasHexData = false, network) {
 
 export function getToWarningObject (to, tokens = [], sendToken = null) {
   let toWarning = null
-  if (sendToken && (ethUtil.toChecksumAddress(to) in contractMap || checkExistingAddresses(to, tokens))) {
+  if (sendToken && (toChecksumAddress(to) in contractMap || checkExistingAddresses(to, tokens))) {
     toWarning = KNOWN_RECIPIENT_ADDRESS_ERROR
   }
   return { to: toWarning }

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.utils.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.utils.js
@@ -1,5 +1,5 @@
 import { multiplyCurrencies, subtractCurrencies } from '../../../../../helpers/utils/conversion-util'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 
 export function calcMaxAmount ({ balance, gasTotal, sendToken, tokenBalance }) {
   const { decimals } = sendToken || {}
@@ -15,8 +15,8 @@ export function calcMaxAmount ({ balance, gasTotal, sendToken, tokenBalance }) {
       },
     )
     : subtractCurrencies(
-      ethUtil.addHexPrefix(balance),
-      ethUtil.addHexPrefix(gasTotal),
+      addHexPrefix(balance),
+      addHexPrefix(gasTotal),
       { toNumericBase: 'hex' },
     )
 }

--- a/ui/app/pages/send/send-footer/send-footer.container.js
+++ b/ui/app/pages/send/send-footer/send-footer.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import {
   addToAddressBook,
   clearSend,
@@ -112,7 +112,7 @@ function mapDispatchToProps (dispatch) {
     },
 
     addToAddressBookIfNew: (newAddress, toAccounts, nickname = '') => {
-      const hexPrefixedAddress = ethUtil.addHexPrefix(newAddress)
+      const hexPrefixedAddress = addHexPrefix(newAddress)
       if (addressIsNew(toAccounts, hexPrefixedAddress)) {
         // TODO: nickname, i.e. addToAddressBook(recipient, nickname)
         dispatch(addToAddressBook(hexPrefixedAddress, nickname))

--- a/ui/app/pages/send/send-footer/send-footer.utils.js
+++ b/ui/app/pages/send/send-footer/send-footer.utils.js
@@ -1,10 +1,10 @@
 import ethAbi from 'ethereumjs-abi'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import { TOKEN_TRANSFER_FUNCTION_SIGNATURE } from '../send.constants'
 
 export function addHexPrefixToObjectValues (obj) {
   return Object.keys(obj).reduce((newObj, key) => {
-    return { ...newObj, [key]: ethUtil.addHexPrefix(obj[key]) }
+    return { ...newObj, [key]: addHexPrefix(obj[key]) }
   }, {})
 }
 
@@ -56,7 +56,7 @@ export function constructUpdatedTx ({
 
   if (sendToken) {
     const data = TOKEN_TRANSFER_FUNCTION_SIGNATURE + Array.prototype.map.call(
-      ethAbi.rawEncode(['address', 'uint256'], [to, ethUtil.addHexPrefix(amount)]),
+      ethAbi.rawEncode(['address', 'uint256'], [to, addHexPrefix(amount)]),
       (x) => ('00' + x.toString(16)).slice(-2),
     ).join('')
 

--- a/ui/app/pages/send/send.constants.js
+++ b/ui/app/pages/send/send.constants.js
@@ -1,4 +1,4 @@
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import { conversionUtil, multiplyCurrencies } from '../../helpers/utils/conversion-util'
 
 const MIN_GAS_PRICE_DEC = '0'
@@ -6,7 +6,7 @@ const MIN_GAS_PRICE_HEX = (parseInt(MIN_GAS_PRICE_DEC)).toString(16)
 const MIN_GAS_LIMIT_DEC = '21000'
 const MIN_GAS_LIMIT_HEX = (parseInt(MIN_GAS_LIMIT_DEC)).toString(16)
 
-const MIN_GAS_PRICE_GWEI = ethUtil.addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
+const MIN_GAS_PRICE_GWEI = addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
   fromDenomination: 'WEI',
   toDenomination: 'GWEI',
   fromNumericBase: 'hex',

--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -20,7 +20,7 @@ import {
 } from './send.constants'
 
 import abi from 'ethereumjs-abi'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 
 export {
   addGasBuffer,
@@ -241,7 +241,7 @@ async function estimateGas ({
     blockGasLimit = MIN_GAS_LIMIT_HEX
   }
 
-  paramsForGasEstimate.gas = ethUtil.addHexPrefix(multiplyCurrencies(blockGasLimit, 0.95, {
+  paramsForGasEstimate.gas = addHexPrefix(multiplyCurrencies(blockGasLimit, 0.95, {
     multiplicandBase: 16,
     multiplierBase: 10,
     roundDown: '0',
@@ -252,7 +252,7 @@ async function estimateGas ({
   try {
     const estimatedGas = await estimateGasMethod(paramsForGasEstimate)
     const estimateWithBuffer = addGasBuffer(estimatedGas.toString(16), blockGasLimit, 1.5)
-    return ethUtil.addHexPrefix(estimateWithBuffer)
+    return addHexPrefix(estimateWithBuffer)
   } catch (error) {
     const simulationFailed = (
       error.message.includes('Transaction execution error.') ||
@@ -260,7 +260,7 @@ async function estimateGas ({
     )
     if (simulationFailed) {
       const estimateWithBuffer = addGasBuffer(paramsForGasEstimate.gas, blockGasLimit, 1.5)
-      return ethUtil.addHexPrefix(estimateWithBuffer)
+      return addHexPrefix(estimateWithBuffer)
     } else {
       throw error
     }
@@ -304,7 +304,7 @@ function generateTokenTransferData ({ toAddress = '0x0', amount = '0x0', sendTok
     return
   }
   return TOKEN_TRANSFER_FUNCTION_SIGNATURE + Array.prototype.map.call(
-    abi.rawEncode(['address', 'uint256'], [toAddress, ethUtil.addHexPrefix(amount)]),
+    abi.rawEncode(['address', 'uint256'], [toAddress, addHexPrefix(amount)]),
     (x) => ('00' + x.toString(16)).slice(-2),
   ).join('')
 }

--- a/ui/app/pages/swap/swap-content/amount-max-button/amount-max-button.utils.js
+++ b/ui/app/pages/swap/swap-content/amount-max-button/amount-max-button.utils.js
@@ -1,12 +1,12 @@
+import { addHexPrefix } from 'ethereumjs-util'
 import { subtractCurrencies } from '../../../../helpers/utils/conversion-util'
-import ethUtil from 'ethereumjs-util'
 
 export function calcMaxAmount ({ balance, estimatedGasCost, fromAsset }) {
   return fromAsset.address
     ? balance
     : subtractCurrencies(
-      ethUtil.addHexPrefix(balance),
-      ethUtil.addHexPrefix(estimatedGasCost || '0'),
+      addHexPrefix(balance),
+      addHexPrefix(estimatedGasCost || '0'),
       { toNumericBase: 'hex' },
     )
 }

--- a/ui/app/pages/swap/swap-content/swap.constants.js
+++ b/ui/app/pages/swap/swap-content/swap.constants.js
@@ -1,4 +1,4 @@
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import { conversionUtil, multiplyCurrencies } from '../../../helpers/utils/conversion-util'
 
 const MIN_GAS_PRICE_DEC = '0'
@@ -6,7 +6,7 @@ const MIN_GAS_PRICE_HEX = (parseInt(MIN_GAS_PRICE_DEC)).toString(16)
 const MIN_GAS_LIMIT_DEC = '21000'
 const MIN_GAS_LIMIT_HEX = (parseInt(MIN_GAS_LIMIT_DEC)).toString(16)
 
-const MIN_GAS_PRICE_GWEI = ethUtil.addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
+const MIN_GAS_PRICE_GWEI = addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
   fromDenomination: 'WEI',
   toDenomination: 'GWEI',
   fromNumericBase: 'hex',

--- a/ui/app/pages/swap/swap.constants.js
+++ b/ui/app/pages/swap/swap.constants.js
@@ -1,4 +1,4 @@
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import { conversionUtil, multiplyCurrencies } from '../../helpers/utils/conversion-util'
 
 const MIN_GAS_PRICE_DEC = '0'
@@ -6,7 +6,7 @@ const MIN_GAS_PRICE_HEX = (parseInt(MIN_GAS_PRICE_DEC)).toString(16)
 const MIN_GAS_LIMIT_DEC = '21000'
 const MIN_GAS_LIMIT_HEX = (parseInt(MIN_GAS_LIMIT_DEC)).toString(16)
 
-const MIN_GAS_PRICE_GWEI = ethUtil.addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
+const MIN_GAS_PRICE_GWEI = addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
   fromDenomination: 'WEI',
   toDenomination: 'GWEI',
   fromNumericBase: 'hex',

--- a/ui/app/pages/swap/swap.utils.js
+++ b/ui/app/pages/swap/swap.utils.js
@@ -1,3 +1,5 @@
+import { addHexPrefix } from 'ethereumjs-util'
+
 import {
   addCurrencies,
   conversionGreaterThan,
@@ -19,8 +21,6 @@ import {
   MIN_GAS_LIMIT_HEX,
   NEGATIVE_ETH_ERROR,
 } from './swap.constants'
-
-import ethUtil from 'ethereumjs-util'
 
 export {
   addGasBuffer,
@@ -165,7 +165,7 @@ async function estimateGasForTransaction ({
   estimateGasMethod,
   blockGasLimit = MIN_GAS_LIMIT_HEX,
 }) {
-  const gas = ethUtil.addHexPrefix(multiplyCurrencies(blockGasLimit, 0.95, {
+  const gas = addHexPrefix(multiplyCurrencies(blockGasLimit, 0.95, {
     multiplicandBase: 16,
     multiplierBase: 10,
     roundDown: '0',
@@ -175,7 +175,7 @@ async function estimateGasForTransaction ({
   try {
     const estimatedGas = await estimateGasMethod({ ...transaction, gas })
     const estimateWithBuffer = addGasBuffer(estimatedGas.toString(16), blockGasLimit, 1.5)
-    return ethUtil.addHexPrefix(estimateWithBuffer)
+    return addHexPrefix(estimateWithBuffer)
   } catch (error) {
     const simulationFailed = (
       error.message.includes('Transaction execution error.') ||
@@ -183,7 +183,7 @@ async function estimateGasForTransaction ({
     )
     if (simulationFailed) {
       const estimateWithBuffer = addGasBuffer(gas, blockGasLimit, 1.5)
-      return ethUtil.addHexPrefix(estimateWithBuffer)
+      return addHexPrefix(estimateWithBuffer)
     } else {
       throw error
     }
@@ -223,7 +223,7 @@ function addGasBuffer (initialGasLimitHex, blockGasLimitHex, bufferMultiplier = 
 }
 
 export function decimalToHex (value) {
-  return ethUtil.addHexPrefix(decimalToHexHelper(value))
+  return addHexPrefix(decimalToHexHelper(value))
 }
 
 export function hexAmountToDecimal (value, asset) {
@@ -234,7 +234,7 @@ export function hexAmountToDecimal (value, asset) {
   }
 
   const multiplier = Math.pow(10, Number(decimals || 0))
-  const decimalValueString = conversionUtil(ethUtil.addHexPrefix(value), {
+  const decimalValueString = conversionUtil(addHexPrefix(value), {
     fromNumericBase: 'hex',
     toNumericBase: 'dec',
     toCurrency: symbol,

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -3,7 +3,7 @@ import pify from 'pify'
 import getBuyEthUrl from '../../../app/scripts/lib/buy-eth-url'
 import { checksumAddress } from '../helpers/utils/util'
 import { calcTokenBalance, estimateGas } from '../pages/send/send.utils'
-import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from 'ethereumjs-util'
 import { ethers } from 'ethers'
 import { fetchLocale, loadRelativeTimeFormatLocaleData } from '../helpers/utils/i18n-helper'
 import { getMethodDataAsync } from '../helpers/utils/transactions.util'
@@ -221,11 +221,11 @@ export function fetchSwapQuote (fromAsset, toAsset, amount, gasPrice, slippage, 
     const selectedAddress = getSelectedAddress(state)
 
     const gasPriceDecimal = gasPrice && ethers.BigNumber.from(
-      ethUtil.addHexPrefix(gasPrice),
+      addHexPrefix(gasPrice),
     ).toString()
 
     const amountDecimal = ethers.BigNumber.from(
-      ethUtil.addHexPrefix(amount),
+      addHexPrefix(amount),
     ).toString()
 
     const conn = exports.getBackgroundConnection()
@@ -276,8 +276,8 @@ export function computeSwapErrors (overrides) {
 
     data = {
       ...data,
-      amount: ethUtil.addHexPrefix(data.amount),
-      balance: ethUtil.addHexPrefix(data.balance),
+      amount: addHexPrefix(data.amount),
+      balance: addHexPrefix(data.balance),
     }
 
     const { fromAsset, amount } = data
@@ -734,7 +734,7 @@ export function approveAllowance (allowance) {
     )
 
     const basicGasEstimates = await dispatch(fetchBasicGasAndTimeEstimates())
-    const gasPrice = ethUtil.addHexPrefix(conversionUtil(basicGasEstimates.fast, {
+    const gasPrice = addHexPrefix(conversionUtil(basicGasEstimates.fast, {
       fromDenomination: 'GWEI',
       toDenomination: 'WEI',
       fromNumericBase: 'dec',
@@ -1109,7 +1109,7 @@ export function signTokenTx (tokenAddress, toAddress, amount, txData) {
   return (dispatch) => {
     dispatch(showLoadingIndication())
     const token = global.eth.contract(abi).at(tokenAddress)
-    token.transfer(toAddress, ethUtil.addHexPrefix(amount), txData)
+    token.transfer(toAddress, addHexPrefix(amount), txData)
       .catch((err) => {
         dispatch(hideLoadingIndication())
         dispatch(displayWarning(err.message))
@@ -2554,7 +2554,7 @@ export function loadingMethodDataFinished () {
 
 export function getContractMethodData (data = '') {
   return (dispatch, getState) => {
-    const prefixedData = ethUtil.addHexPrefix(data)
+    const prefixedData = addHexPrefix(data)
     const fourBytePrefix = prefixedData.slice(0, 10)
     const { knownMethodData } = getState().metamask
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10196,17 +10196,6 @@ ethereumjs-tx@2.1.2, ethereumjs-tx@^2.1.1, ethereumjs-tx@^2.1.2:
     ethereumjs-common "^1.5.0"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-util@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.1.0.tgz#8e9646c13322e75a9c593cf705d27d4a51c991c0"
-  integrity sha1-jpZGwTMi51qcWTz3BdJ9SlHJkcA=
-  dependencies:
-    bn.js "^4.8.0"
-    create-hash "^1.1.2"
-    keccak "^1.0.2"
-    rlp "^2.0.0"
-    secp256k1 "^3.0.1"
-
 ethereumjs-util@6.2.1, ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0, ethereumjs-util@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
@@ -10248,6 +10237,18 @@ ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.9:
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
   integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
+
+ethereumjs-util@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz#e2b43a30bfcdbcb432a4eb42bd5f2393209b3fd5"
+  integrity sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==
   dependencies:
     "@types/bn.js" "^5.1.0"
     bn.js "^5.1.2"
@@ -14833,16 +14834,6 @@ keccak@3.0.1, keccak@^3.0.0:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-keccak@^1.0.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/keccak/-/keccak-1.4.0.tgz#572f8a6dbee8e7b3aa421550f9e6408ca2186f80"
-  integrity sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==
-  dependencies:
-    bindings "^1.2.1"
-    inherits "^2.0.3"
-    nan "^2.2.1"
-    safe-buffer "^5.1.0"
-
 keygrip@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
@@ -16581,7 +16572,7 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.0.5, nan@^2.0.8, nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.2.1:
+nan@^2.0.5, nan@^2.0.8, nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==


### PR DESCRIPTION
|GitHub|https://github.com/brave/brave-browser/issues/17160
-|-|

### Summary of changes

* Major version upgrade of `ethereumjs-util`.
* Update import statements to work with the new module system.
* Use `keccak` instead of `sha3`.
* Remove unused `BN` initialization code in `ui/app/helpers/utils/util.js`, and corresponding tests.