### PR TITLE
Remove engines requirement from ethereum-remote-client

### DIFF
--- a/development/build/publish.js
+++ b/development/build/publish.js
@@ -10,6 +10,7 @@ function createBravePublishTasks () {
         delete json.browserify
         json.devDependencies = {}
         json.dependencies = {}
+        json.engines = {}
         json.scripts = {}
         return json
       }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-remote-client",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "private": true,
   "scripts": {
     "start": "yarn build dev",


### PR DESCRIPTION
We can do this because npm package is just a transpiled output directory