### PR TITLE
chore: update tokenlists and prevent blacklisted tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,15 @@
     "netmask": "^2.0.1",
     "ganache-core/lodash": "^4.17.21",
     "underscore": "^1.12.1",
-    "url-parse": "^1.5.0",
+    "url-parse": "^1.5.2",
     "ssri": "^6.0.2",
-    "hosted-git-info": "^3.0.8"
+    "hosted-git-info": "^3.0.8",
+    "**/swarm-js/tar": "^4.4.15",
+    "**/node-pre-gyp/tar": "^4.4.15",
+    "geckodriver/tar": "^6.1.2",
+    "**/node-sass/node-gyp/tar": "^4.4.3",
+    "**/path-parse": "^1.0.7",
+    "**/jszip": "^3.7.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@formatjs/intl-relativetimeformat": "^5.2.6",
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@material-ui/core": "^4.11.0",
-    "@metamask/contract-metadata": "^1.25.0",
+    "@metamask/contract-metadata": "1.26.0",
     "@metamask/controllers": "^2.0.5",
     "@metamask/eth-ledger-bridge-keyring": "github:brave/eth-ledger-bridge-keyring#6db82c15435f9ae47dadbc1fc19586552a7044eb",
     "@metamask/etherscan-link": "^1.1.0",

--- a/ui/app/pages/swap/assets/assets.mainnet.json
+++ b/ui/app/pages/swap/assets/assets.mainnet.json
@@ -84,6 +84,12 @@
         "decimals": 18
     },
     {
+        "address": "0xFFC97d72E13E01096502Cb8Eb52dEe56f74DAD7B",
+        "symbol": "AAAVE",
+        "name": "Aave AAVE",
+        "decimals": 18
+    },
+    {
         "address": "0x05Ec93c0365baAeAbF7AefFb0972ea7ECdD39CF1",
         "symbol": "ABAT",
         "name": "Aave BAT",
@@ -186,6 +192,12 @@
         "decimals": 18
     },
     {
+        "address": "0x358AA737e033F34df7c54306960a38d09AaBd523",
+        "symbol": "ARES",
+        "name": "Ares Protocol",
+        "decimals": 18
+    },
+    {
         "address": "0xfec0cF7fE078a500abf15F1284958F22049c2C7e",
         "symbol": "ART",
         "name": "Maecenas",
@@ -228,6 +240,18 @@
         "decimals": 18
     },
     {
+        "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+        "symbol": "AUDIO",
+        "name": "Audius",
+        "decimals": 18
+    },
+    {
+        "address": "0xB9D7CB55f463405CDfBe4E90a6D2Df01C2B92BF1",
+        "symbol": "AUNI",
+        "name": "Aave UNI",
+        "decimals": 18
+    },
+    {
         "address": "0xBcca60bB61934080951369a648Fb03DF4F96263C",
         "symbol": "AUSDC",
         "name": "Aave USDC",
@@ -252,9 +276,21 @@
         "decimals": 18
     },
     {
+        "address": "0x030bA81f1c18d280636F32af80b9AAd02Cf0854e",
+        "symbol": "AWETH",
+        "name": "Aave WETH",
+        "decimals": 18
+    },
+    {
         "address": "0x71F85B2E46976bD21302B64329868fd15eb0D127",
         "symbol": "AXN",
         "name": "Axion",
+        "decimals": 18
+    },
+    {
+        "address": "0x5165d24277cD063F5ac44Efd447B27025e888f37",
+        "symbol": "AYFI",
+        "name": "Aave YFI",
         "decimals": 18
     },
     {
@@ -412,6 +448,12 @@
         "symbol": "CHSB",
         "name": "SwissBorg",
         "decimals": 8
+    },
+    {
+        "address": "0x75739d5944534115d7C54ee8C73F186D793BAE02",
+        "symbol": "CO2",
+        "name": "Collective",
+        "decimals": 18
     },
     {
         "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
@@ -636,6 +678,12 @@
         "decimals": 18
     },
     {
+        "address": "0x1Da87b114f35E1DC91F72bF57fc07A768Ad40Bb0",
+        "symbol": "EQZ",
+        "name": "Equalizer",
+        "decimals": 18
+    },
+    {
         "address": "0xb1CD6e4153B2a390Cf00A6556b0fC1458C4A5533",
         "symbol": "ETHBNT",
         "name": "ETHBNT Relay",
@@ -694,6 +742,12 @@
         "symbol": "FUN",
         "name": "FUNToken",
         "decimals": 8
+    },
+    {
+        "address": "0x970B9bB2C0444F5E81e9d0eFb84C8ccdcdcAf84d",
+        "symbol": "FUSE",
+        "name": "Fuse",
+        "decimals": 18
     },
     {
         "address": "0x35bD01FC9d6D5D81CA9E055Db88Dc49aa2c699A8",
@@ -816,9 +870,21 @@
         "decimals": 18
     },
     {
+        "address": "0x544c42fBB96B39B21DF61cf322b5EDC285EE7429",
+        "symbol": "INSUR",
+        "name": "InsurAce",
+        "decimals": 18
+    },
+    {
         "address": "0x0DB8D8b76BC361bAcbB72E2C491E06085A97Ab31",
         "symbol": "IQN",
         "name": "IQeon",
+        "decimals": 18
+    },
+    {
+        "address": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC",
+        "symbol": "JASMY",
+        "name": "JasmyCoin",
         "decimals": 18
     },
     {
@@ -832,6 +898,12 @@
         "symbol": "JOY",
         "name": "JOYSO",
         "decimals": 6
+    },
+    {
+        "address": "0x6E765D26388A17A6e86c49A8E41DF3F58aBcd337",
+        "symbol": "KANGAL",
+        "name": "Kangal",
+        "decimals": 18
     },
     {
         "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
@@ -936,6 +1008,12 @@
         "decimals": 18
     },
     {
+        "address": "0x75387e1287Dd85482aB66102DA9f6577E027f609",
+        "symbol": "MAI",
+        "name": "Mindsync",
+        "decimals": 18
+    },
+    {
         "address": "0x0cae9e4d663793c2a2A0b211c1Cf4bBca2B9cAa7",
         "symbol": "MAMZN",
         "name": "Mirrored Amazon",
@@ -951,12 +1029,6 @@
         "address": "0x23Ccc43365D9dD3882eab88F43d515208f832430",
         "symbol": "MAS",
         "name": "Midas Protocol",
-        "decimals": 18
-    },
-    {
-        "address": "0x1C9491865a1DE77C5b6e19d2E6a5F1D7a6F2b25F",
-        "symbol": "MATTER",
-        "name": "AntiMatter",
         "decimals": 18
     },
     {
@@ -1122,6 +1194,12 @@
         "decimals": 8
     },
     {
+        "address": "0x4a615bB7166210CCe20E6642a6f8Fb5d4D044496",
+        "symbol": "NAOS",
+        "name": "NAOS Finance",
+        "decimals": 18
+    },
+    {
         "address": "0xEB58343b36C7528F23CAAe63a150240241310049",
         "symbol": "NBU",
         "name": "Nimbus",
@@ -1188,6 +1266,12 @@
         "decimals": 18
     },
     {
+        "address": "0xDb05EA0877A2622883941b939f0bb11d1ac7c400",
+        "symbol": "OPCT",
+        "name": "Opacity",
+        "decimals": 18
+    },
+    {
         "address": "0xff56Cc6b1E6dEd347aA0B7676C85AB0B3D08B0FA",
         "symbol": "ORBS",
         "name": "Orbs",
@@ -1238,7 +1322,7 @@
     {
         "address": "0xeca82185adCE47f39c684352B0439f030f860318",
         "symbol": "PERL",
-        "name": "Perlin",
+        "name": "PERL eco",
         "decimals": 18
     },
     {
@@ -1482,6 +1566,18 @@
         "decimals": 18
     },
     {
+        "address": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
+        "symbol": "RSR",
+        "name": "Reserve Rights Toke",
+        "decimals": 18
+    },
+    {
+        "address": "0x196f4727526eA7FB1e17b2071B3d8eAA38486988",
+        "symbol": "RSV",
+        "name": "Reserve",
+        "decimals": 18
+    },
+    {
         "address": "0x3d1BA9be9f66B8ee101911bC36D3fB562eaC2244",
         "symbol": "RVT",
         "name": "Rivetz",
@@ -1515,6 +1611,12 @@
         "address": "0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb",
         "symbol": "SETH",
         "name": "sETH",
+        "decimals": 18
+    },
+    {
+        "address": "0x84810bcF08744d5862B8181f12d17bfd57d3b078",
+        "symbol": "SGT",
+        "name": "SharedStake Governa",
         "decimals": 18
     },
     {
@@ -1632,12 +1734,6 @@
         "decimals": 18
     },
     {
-        "address": "0xeF31Cb88048416E301Fee1eA13e7664b887BA7e8",
-        "symbol": "SYAX",
-        "name": "Staked yAxis",
-        "decimals": 18
-    },
-    {
         "address": "0x8282df223AC402d04B2097d16f758Af4F70e7Db0",
         "symbol": "SYFL",
         "name": "YFLink Synthetic",
@@ -1647,6 +1743,12 @@
         "address": "0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4",
         "symbol": "SYLO",
         "name": "Sylo",
+        "decimals": 18
+    },
+    {
+        "address": "0x182F4c4C97cd1c24E1Df8FC4c053E5C47bf53Bef",
+        "symbol": "TANGO",
+        "name": "keyTango",
         "decimals": 18
     },
     {
@@ -1734,6 +1836,12 @@
         "decimals": 18
     },
     {
+        "address": "0x898BAD2774EB97cF6b94605677F43b41871410B1",
+        "symbol": "VETH2",
+        "name": "vEth2",
+        "decimals": 18
+    },
+    {
         "address": "0xfeF4185594457050cC9c23980d301908FE057Bb1",
         "symbol": "VIDT",
         "name": "VIDT Datalink",
@@ -1743,6 +1851,12 @@
         "address": "0x1b40183EFB4Dd766f11bDa7A7c3AD8982e998421",
         "symbol": "VSP",
         "name": "Vesper Finance",
+        "decimals": 18
+    },
+    {
+        "address": "0x1cF4592ebfFd730c7dc92c1bdFFDfc3B9EfCf29a",
+        "symbol": "WAVES",
+        "name": "Waves",
         "decimals": 18
     },
     {
@@ -1842,9 +1956,9 @@
         "decimals": 18
     },
     {
-        "address": "0xC7e43A1c8E118aA2965F5EAbe0e718D83DB7A63C",
-        "symbol": "ZCRT",
-        "name": "ZCore Token",
+        "address": "0x5150956E082C748Ca837a5dFa0a7C10CA4697f9c",
+        "symbol": "ZDEX",
+        "name": "Zeedex",
         "decimals": 18
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,15 +2014,15 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
+"@metamask/contract-metadata@1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.26.0.tgz#06be4f4dc645da69f6364f75cb2bd47afa642fe6"
+  integrity sha512-58A8csapIPoc854n6AI+3jwJcQfh75BzVrl6SAySgJ9fWTa1XItm9Tx/ORaqYrwaR/9JqH4SnkbXtqyFwuUL6w==
+
 "@metamask/contract-metadata@^1.19.0":
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.22.0.tgz#55cc84756c703c433176b484b1d34f0e03d16d1e"
   integrity sha512-t4ijbU+4OH9UAlrPkfLPFo6KmkRTRZJHB+Vly4ajF8oZMnota5YjVVl/SmltsoRC9xvJtRn9DUVf3YMHMIdofw==
-
-"@metamask/contract-metadata@^1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.25.0.tgz#442ace91fb40165310764b68d8096d0017bb0492"
-  integrity sha512-yhmYB9CQPv0dckNcPoWDcgtrdUp0OgK0uvkRE5QIBv4b3qENI1/03BztvK2ijbTuMlORUpjPq7/1MQDUPoRPVw==
 
 "@metamask/controllers@^2.0.5":
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5693,13 +5693,6 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
-
 bluebird@3.7.2, bluebird@^3.3.5, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -6706,7 +6699,7 @@ chokidar@^3.4.1:
   optionalDependencies:
     fsevents "~2.3.1"
 
-chownr@^1.1.1, chownr@^1.1.2:
+chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -11643,7 +11636,7 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
+fs-minipass@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
   integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
@@ -11703,7 +11696,7 @@ fsevents@~2.3.1:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-fstream@^1.0.0, fstream@^1.0.12:
+fstream@^1.0.0:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -14783,10 +14776,10 @@ jss@10.5.1, jss@^10.5.1:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
-jszip@^3.5.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.6.0.tgz#839b72812e3f97819cc13ac4134ffced95dd6af9"
-  integrity sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==
+jszip@^3.5.0, jszip@^3.7.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.7.1.tgz#bd63401221c15625a1228c556ca8a68da6fda3d9"
+  integrity sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==
   dependencies:
     lie "~3.3.0"
     pako "~1.0.2"
@@ -16317,7 +16310,7 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+minipass@^2.6.0, minipass@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
   integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
@@ -16332,14 +16325,14 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
-minizlib@^1.2.1:
+minizlib@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
   integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
     minipass "^2.9.0"
 
-minizlib@^2.1.0:
+minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -17917,10 +17910,10 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+path-parse@^1.0.6, path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-platform@~0.11.15:
   version "0.11.15"
@@ -20337,7 +20330,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -22136,39 +22129,30 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.2.tgz#5df17813468a6264ff14f766886c622b84ae2f39"
-  integrity sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==
+tar@6.0.2, tar@^6.1.2:
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.8.tgz#4fc50cfe56511c538ce15b71e05eebe66530cbd4"
+  integrity sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
     minipass "^3.0.0"
-    minizlib "^2.1.0"
+    minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tar@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
-  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
+tar@^2.0.0, tar@^4, tar@^4.0.2, tar@^4.4.15, tar@^4.4.3:
+  version "4.4.17"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.17.tgz#44be5e3fa8353ee1d11db3b1401561223a5c3985"
+  integrity sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==
   dependencies:
-    block-stream "*"
-    fstream "^1.0.12"
-    inherits "2"
-
-tar@^4, tar@^4.0.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
+    chownr "^1.1.4"
+    fs-minipass "^1.2.7"
+    minipass "^2.9.0"
+    minizlib "^1.3.3"
+    mkdirp "^0.5.5"
+    safe-buffer "^5.2.1"
+    yallist "^3.1.1"
 
 tarn@^1.1.4:
   version "1.1.5"
@@ -23036,10 +23020,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3, url-parse@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
-  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
+url-parse@^1.4.3, url-parse@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
+  integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
@@ -24281,7 +24265,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.0, yallist@^3.0.2, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
This PR ensures no token is part of our swap asset list that has been blacklisted by Uniswap. We already had some sort of protection against this, since we made sure tokens belong to the `@metamask/contract-metadata` package.

Summary:
* Upgraded `@metamask/contract-metadata` to the latest version supporting Node 10.
* Refactored the swap assets registry script to filter out tokens in Uniswap's official blacklist.