### PR TITLE
fix(eip1559): fix broken keyring handling legacy brave seeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,5 @@ before_install:
 branches:
   only:
     - master
-    - eip1559
 script:
   - yarn test:brave

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@brave/eth-keyring-controller": "github:brave/KeyringController#439c76e928cda5dc72e03bdf83b1d7deaf0b752e",
+    "@brave/eth-keyring-controller": "github:brave/KeyringController#0769514cea07e85ae190f30765d0a301c631c56b",
     "@brave/eth-token-tracker": "^3.0.0",
     "@download/blockies": "^1.0.3",
     "@ethereumjs/common": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,16 +958,16 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@brave/eth-keyring-controller@github:brave/KeyringController#439c76e928cda5dc72e03bdf83b1d7deaf0b752e":
-  version "5.4.3"
-  resolved "https://codeload.github.com/brave/KeyringController/tar.gz/439c76e928cda5dc72e03bdf83b1d7deaf0b752e"
+"@brave/eth-keyring-controller@github:brave/KeyringController#0769514cea07e85ae190f30765d0a301c631c56b":
+  version "5.4.4"
+  resolved "https://codeload.github.com/brave/KeyringController/tar.gz/0769514cea07e85ae190f30765d0a301c631c56b"
   dependencies:
     argon2-wasm "^0.9.0"
     bip39 "^2.4.0"
     bluebird "^3.5.0"
     brave-crypto "^0.3.1"
     browser-passworder "^2.0.3"
-    eth-hd-keyring brave/eth-hd-keyring#4488dac
+    eth-hd-keyring brave/eth-hd-keyring#3f5be32b34dba0d47c607010db4c8487725c5598
     eth-sig-util "^3.0.1"
     eth-simple-keyring "^4.2.0"
     ethereumjs-util "^7.1.0"
@@ -9952,9 +9952,9 @@ eth-hd-keyring@^3.6.0:
     ethereumjs-util "^7.0.9"
     ethereumjs-wallet "^1.0.1"
 
-eth-hd-keyring@brave/eth-hd-keyring#4488dac:
-  version "2.1.0"
-  resolved "https://codeload.github.com/brave/eth-hd-keyring/tar.gz/4488dac00a02d633bd7c4265fcbf2bc659830103"
+eth-hd-keyring@brave/eth-hd-keyring#3f5be32b34dba0d47c607010db4c8487725c5598:
+  version "2.1.1"
+  resolved "https://codeload.github.com/brave/eth-hd-keyring/tar.gz/3f5be32b34dba0d47c607010db4c8487725c5598"
   dependencies:
     bip39 "^2.2.0"
     brave-crypto "^0.3.2"


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/18052

### TODO
- [x] Merge https://github.com/brave/KeyringController/pull/18
- [ ] Update package version of `@brave/eth-keyring-controller`.

### QA test plan

**Primer**: Wallets created with Crypto Wallets Version 1.0.26 or earlier use legacy Brave seeds. The test plan only relates to transaction/message signing. See [this Wiki article](https://github.com/brave/brave-browser/wiki/Brave-Ethereum-Remote-Client-Wallet-Seed-Information) for details on the key derivation scheme.

Before starting the QA, you need to restore legacy 24-word seeds into the wallet. Please ping me privately if you need one with pre-loaded funds.

| Test | Dapp | Network |
|----|-------|--------|
| ETH-DAI swap | Sushiswap | Ethereum mainnet |
| DAI-USDT swap | Quickswap | Polygon mainnet |
| USDT-USDC swap | Curve | Polygon mainnet |
| MATIC-DAI swap | 1inch | Polygon mainnet |
| Deposit MATIC | Aave | Polygon mainnet |
| Withdraw MATIC | Aave | Polygon mainnet |
| Send MATIC | Brave wallet | Polygon mainnet |
| Send BNB | Brave wallet | Binance Smart Chain mainnet |
| Send ETH | Brave wallet | Ethereum mainnet |
| Simple message signing | [sample dapp](https://clever-easley-b06b7a.netlify.app/) - should display account addresses after signing | - |