### PR TITLE
Uses batch file on Windows

### DIFF
--- a/development/build/task.js
+++ b/development/build/task.js
@@ -1,5 +1,6 @@
 const EventEmitter = require('events')
 const { spawn } = require('child_process')
+const { platform } = require('os')
 
 const tasks = {}
 const taskEvents = new EventEmitter()
@@ -54,7 +55,8 @@ function runInChildProcess (task) {
     throw new Error(`MetaMask build: runInChildProcess unable to identify task name`)
   }
   return instrumentForTaskStats(taskName, async () => {
-    const childProcess = spawn('yarn', ['build', taskName, '--skip-stats'])
+    const command = platform() === 'win32' ? 'yarn.cmd' : 'yarn'
+    const childProcess = spawn(command, ['build', taskName, '--skip-stats'])
     // forward logs to main process
     // skip the first stdout event (announcing the process command)
     childProcess.stdout.once('data', () => {


### PR DESCRIPTION
The spawn method will locate the wrong 'yarn' on Windows. When installed, Yarn will drop a `yarn`, `yarn.cmd`, and `yarn.js` onto the system. Numerous issues on yarnpkg/yarn detail the types of problems Windows users can face when calling _yarn_ via script; calling yarn.cmd will disambiguate the request.