### PR TITLE
Remove Phishfort lists

### DIFF
--- a/app/scripts/controllers/phishing-controller.js
+++ b/app/scripts/controllers/phishing-controller.js
@@ -1,30 +1,8 @@
 import { PhishingController } from '@metamask/controllers'
 
-const PhishingDetector = require('eth-phishing-detect/src/detector')
-
 export default class BravePhishingController extends PhishingController {
   constructor (config, state) {
     super(config, state)
     this.configUrl = 'https://mainnet-infura-api.brave.com/blacklist'
-    this.phishfortResourceUrl = 'https://mainnet-infura-api.brave.com/phishfort'
-  }
-
-  async fetchPhishfortDenyList () {
-    const phishFortDenylist = await fetch(this.phishfortResourceUrl) // eslint-disable-line no-undef
-    return await phishFortDenylist.json()
-  }
-
-  async update (state, overwrite = false) {
-    if (state.phishing && state.phishing.blacklist) {
-      const denyList = await this.fetchPhishfortDenyList()
-      if (denyList) {
-        state.phishing.blacklist = [
-          ...state.phishing.blacklist,
-          ...denyList,
-        ]
-        this.detector = new PhishingDetector(state.phishing)
-      }
-    }
-    super.update(state, overwrite)
   }
 }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "eth-json-rpc-middleware": "^7.0.1",
     "eth-keyring-controller": "^6.2.1",
     "eth-method-registry": "^1.2.0",
-    "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
     "eth-sig-util": "^2.3.0",
     "eth-trezor-keyring": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10524,7 +10524,7 @@ eth-method-registry@^1.2.0:
   dependencies:
     ethjs "^0.3.0"
 
-eth-phishing-detect@^1.1.13, eth-phishing-detect@^1.1.4:
+eth-phishing-detect@^1.1.13:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/eth-phishing-detect/-/eth-phishing-detect-1.1.14.tgz#64dcd35dd3a7a95266d875cbc5280842cda133d7"
   integrity sha512-nMQmzrgYabZ52YpuKZ38lStJy9Lozww2WBhyFbu/oepjsZzPvnl2KwJ6TJ78kk14USdl8Htt+eEMk2WAdAjlWg==


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/18750

Removes the Phishfort lists from constructor and update method. For additional context, see https://bravesoftware.slack.com/archives/C8MP8ME4C/p1633376174202100.