### PR TITLE
signature-request: remove unload listener on unmount

### DIFF
--- a/ui/app/components/app/signature-request/signature-request.component.js
+++ b/ui/app/components/app/signature-request/signature-request.component.js
@@ -27,21 +27,29 @@ export default class SignatureRequest extends PureComponent {
   }
 
   componentDidMount () {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
+      window.addEventListener('beforeunload', this._beforeUnload)
+    }
+  }
+
+  componentWillUnmount () {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
+      window.removeEventListener('beforeunload', this._beforeUnload)
+    }
+  }
+
+  _beforeUnload (event) {
     const { clearConfirmTransaction, cancel } = this.props
     const { metricsEvent } = this.context
-    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
-      window.addEventListener('beforeunload', (event) => {
-        metricsEvent({
-          eventOpts: {
-            category: 'Transactions',
-            action: 'Sign Request',
-            name: 'Cancel Sig Request Via Notification Close',
-          },
-        })
-        clearConfirmTransaction()
-        cancel(event)
-      })
-    }
+    metricsEvent({
+      eventOpts: {
+        category: 'Transactions',
+        action: 'Sign Request',
+        name: 'Cancel Sig Request Via Notification Close',
+      },
+    })
+    clearConfirmTransaction()
+    cancel(event)
   }
 
   formatWallet (wallet) {


### PR DESCRIPTION
this fix prevents the error `MetaMask Message Signature: User denied message signature.` on async signing (ex: ledger hardware wallet). without it, the signing process is canceled when the wallet ui closes. 
together with https://github.com/brave/eth-ledger-bridge-keyring/pull/3, they fix `signTypedData` functionality for ledger.